### PR TITLE
backslash-menu

### DIFF
--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -34,5 +34,8 @@
     "react-dom": "^18.2.0",
     "shared": "*",
     "shared-react": "*"
+  },
+  "dependencies": {
+    "@floating-ui/dom": "^1.6.1"
   }
 }

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -15,6 +15,7 @@ import editorTheme from "./themes/editor-theme";
 import ScriptureReferencePlugin from "./plugins/ScriptureReferencePlugin";
 import ToolbarPlugin from "./plugins/toolbar/ToolbarPlugin";
 import { ViewOptions } from "./adaptors/view-options.utils";
+import BackslashPlugin from "./plugins/BackslashPlugin";
 
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
@@ -108,6 +109,7 @@ export default function Editor<TLogger extends LoggerBasic>({
             viewOptions={viewOptions}
             logger={logger}
           />
+          <BackslashPlugin />
         </div>
       </div>
     </LexicalComposer>

--- a/packages/platform/src/editor/components/BackslashMenu/BackslashMenu.tsx
+++ b/packages/platform/src/editor/components/BackslashMenu/BackslashMenu.tsx
@@ -1,0 +1,52 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getSelection, $isRangeSelection } from "lexical";
+import { forwardRef, useEffect, useState } from "react";
+import BlockFormatDropDown from "../../plugins/toolbar/BlockFormatDropDown";
+
+export type BackslashMenuCoords = { x: number; y: number } | undefined;
+
+type BackslashMenuProps = {
+  editor: ReturnType<typeof useLexicalComposerContext>[0];
+  coords: BackslashMenuCoords;
+  closeMenu?: () => void;
+};
+
+export const BackslashMenu = forwardRef<HTMLDivElement, BackslashMenuProps>(
+  function BackslashMenu(props, ref) {
+    const { editor, coords, closeMenu } = props;
+    const [isEditable] = useState(() => editor.isEditable());
+
+    const shouldShow = coords !== undefined;
+    useEffect(() => {
+      const unregisterListener = editor.registerUpdateListener(({ editorState }) => {
+        editorState.read(() => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) return;
+        });
+      });
+      return unregisterListener;
+    }, [editor]);
+
+    return (
+      <div
+        ref={ref}
+        className="flex items-center justify-between bg-slate-100 border-[1px] border-slate-300 rounded-md p-1 gap-1"
+        aria-hidden={!shouldShow}
+        style={{
+          position: "absolute",
+          top: coords?.y,
+          left: coords?.x,
+          visibility: shouldShow ? "visible" : "hidden",
+          opacity: shouldShow ? 1 : 0,
+        }}
+      >
+        <BlockFormatDropDown
+          disabled={!isEditable}
+          blockType="para:ms1"
+          editor={editor}
+          closeMenu={closeMenu}
+        />
+      </div>
+    );
+  },
+);

--- a/packages/platform/src/editor/components/BackslashMenu/useBackslashMenu.ts
+++ b/packages/platform/src/editor/components/BackslashMenu/useBackslashMenu.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Detect if the user currently presses or releases a key.
+ */
+
+export function useBackslashMenu() {
+  const [isKeyDown, setIsKeyDown] = useState(false);
+  const [isKeyReleased, setIsKeyReleased] = useState(true);
+
+  const handleKeyUp = (event: { key: string }) => {
+    if (event.key === "\\") {
+      setIsKeyDown(false);
+      setIsKeyReleased(true);
+    }
+  };
+
+  const handleKeyDown = (event: { key: string }) => {
+    if (event.key === "\\") {
+      setIsKeyDown(true);
+      setIsKeyReleased(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  return { isKeyDown, isKeyReleased };
+}

--- a/packages/platform/src/editor/plugins/BackslashPlugin.tsx
+++ b/packages/platform/src/editor/plugins/BackslashPlugin.tsx
@@ -1,0 +1,83 @@
+import { computePosition } from "@floating-ui/dom";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getSelection, $isRangeSelection } from "lexical";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { BackslashMenu, BackslashMenuCoords } from "../components/BackslashMenu/BackslashMenu";
+import { useBackslashMenu } from "../components/BackslashMenu/useBackslashMenu";
+
+const DOM_ELEMENT = document.body;
+
+export default function FloatingMenuPlugin() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [coords, setCoords] = useState<BackslashMenuCoords>(undefined);
+  const [editor] = useLexicalComposerContext();
+  const [backslashOpen, setBackslashOpen] = useState(false);
+
+  const { isKeyDown, isKeyReleased } = useBackslashMenu();
+
+  const calculatePosition = useCallback(() => {
+    const domSelection = getSelection();
+    const domRange = domSelection?.rangeCount !== 0 && domSelection?.getRangeAt(0);
+    if (!domRange || !ref.current) {
+      return setCoords(undefined);
+    }
+    computePosition(domRange, ref.current, { placement: "bottom-start" })
+      .then((pos) => {
+        setCoords({ x: pos.x, y: pos.y - 10 });
+      })
+      .catch(() => {
+        setCoords(undefined);
+      });
+  }, [isKeyDown]);
+
+  const closeMenu = () => {
+    setBackslashOpen(false);
+  };
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "\\") {
+        event.preventDefault();
+        calculatePosition();
+        setBackslashOpen((prev) => !prev);
+      }
+    };
+    return editor.registerRootListener(
+      (rootElement: HTMLElement | null, prevRootElement: HTMLElement | null) => {
+        if (prevRootElement !== null) {
+          prevRootElement.removeEventListener("keydown", onKeyDown);
+        }
+        if (rootElement !== null) {
+          rootElement.addEventListener("keydown", onKeyDown);
+        }
+      },
+    );
+  }, [editor]);
+
+  const $handleSelectionChange = useCallback(() => {
+    if (editor.isComposing() || editor.getRootElement() !== document.activeElement) {
+      setCoords(undefined);
+      return;
+    }
+    const selection = $getSelection();
+    if ($isRangeSelection(selection) && !selection.anchor.is(selection.focus) && backslashOpen) {
+      calculatePosition();
+    } else {
+      setCoords(undefined);
+    }
+  }, [editor, calculatePosition, backslashOpen]);
+
+  const show = coords !== undefined && backslashOpen;
+
+  useEffect(() => {
+    if (!show && isKeyReleased) {
+      editor.getEditorState().read(() => $handleSelectionChange());
+    }
+  }, [isKeyReleased, $handleSelectionChange, editor]);
+
+  return createPortal(
+    <BackslashMenu ref={ref} editor={editor} coords={coords} closeMenu={closeMenu} />,
+    DOM_ELEMENT,
+  );
+}

--- a/packages/platform/src/editor/plugins/toolbar/BlockFormatDropDown.tsx
+++ b/packages/platform/src/editor/plugins/toolbar/BlockFormatDropDown.tsx
@@ -59,10 +59,12 @@ export default function BlockFormatDropDown({
   editor,
   blockType,
   disabled = false,
+  closeMenu,
 }: {
   editor: LexicalEditor;
   blockType: string;
   disabled?: boolean;
+  closeMenu?: () => void;
 }): JSX.Element {
   const formatPara = (selectedBlockType: string) => {
     editor.update(() => {
@@ -71,6 +73,9 @@ export default function BlockFormatDropDown({
         $setBlocksType(selection, () => $createParaNode(typeToStyle(selectedBlockType)));
       }
     });
+    if (closeMenu) {
+      closeMenu();
+    }
   };
 
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,10 @@ importers:
         version: link:../shared
 
   packages/platform:
+    dependencies:
+      '@floating-ui/dom':
+        specifier: ^1.6.1
+        version: 1.6.1
     devDependencies:
       '@lexical/code':
         specifier: ^0.13.1
@@ -1989,12 +1993,25 @@ packages:
       '@floating-ui/utils': 0.1.6
     dev: true
 
+  /@floating-ui/core@1.6.0:
+    resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
+    dependencies:
+      '@floating-ui/utils': 0.2.1
+    dev: false
+
   /@floating-ui/dom@1.5.3:
     resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
     dependencies:
       '@floating-ui/core': 1.5.0
       '@floating-ui/utils': 0.1.6
     dev: true
+
+  /@floating-ui/dom@1.6.1:
+    resolution: {integrity: sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==}
+    dependencies:
+      '@floating-ui/core': 1.6.0
+      '@floating-ui/utils': 0.2.1
+    dev: false
 
   /@floating-ui/react-dom@2.0.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==}
@@ -2010,6 +2027,10 @@ packages:
   /@floating-ui/utils@0.1.6:
     resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: true
+
+  /@floating-ui/utils@0.2.1:
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+    dev: false
 
   /@graphql-tools/merge@8.4.2(graphql@16.8.1):
     resolution: {integrity: sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==}


### PR DESCRIPTION
Fixes #16  
- Backslash menu for platform
- currently opens the `BlockFormatDropDown` toolbar but any component can be passed to it as a child.