### PR TITLE
uncontrolled USJ props

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -16,9 +16,8 @@ title: ScriptureData—Editor flow
 ---
 graph TB
   DB[(DB)] <-- USX --> C
-  C[USX-USJ converter] -- USJ --> A
+  C[USX-USJ converter] <-- USJ --> A
   A[USJ-Editor adapter] -- Editor State --> Editor
-  A -. NYI* .-> C
   Editor -. NYI* .-> A
 
   Editor ~~~ Key[NYI* - Not Yet Implemented]
@@ -33,10 +32,13 @@ npm install @biblionexus-foundation/platform-editor
 
 ## Usage
 
+**Note:** this is an [uncontrolled React component](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components).
+
 ```typescript
-import { Editor, usxStringToJson } from '@biblionexus-foundation/platform-editor';
+import { Editor, EditorRef, usxStringToUsj } from '@biblionexus-foundation/platform-editor';
 import { RefSelector } from 'platform-bible-react';
 
+const emptyUsx = '<usx version="3.0" />';
 const usx = `
 <?xml version="1.0" encoding="utf-8"?>
 <usx version="3.0">
@@ -50,10 +52,16 @@ const usx = `
   <para style="q2" vid="PSA 1:1">nor sit in the seat of scoffers;<verse eid="PSA 1:1" /></para>
 </usx>
 `;
-const usj = usxStringToJson(usx);
+const defaultUsj = usxStringToUsj(emptyUsx);
+const defaultScrRef = { /* PSA */ bookNum: 19, chapterNum: 1, verseNum: 1 };
 
 export default function App() {
+  const editorRef = useRef<EditorRef>(null);
   const [scrRef, setScrRef] = useState(defaultScrRef);
+
+  setTimeout(() => {
+    editorRef.current?.setUsj(usxStringToUsj(usx));
+  }, 1000);
 
   return (
     <>
@@ -61,7 +69,8 @@ export default function App() {
         <RefSelector handleSubmit={setScrRef} scrRef={scrRef} />
       </div>
       <Editor
-        usj={usj}
+        defaultUsj={defaultUsj}
+        ref={editorRef}
         scrRef={scrRef}
         setScrRef={setScrRef}
         logger={console}

--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -56,7 +56,7 @@ const defaultUsj = usxStringToUsj(emptyUsx);
 const defaultScrRef = { /* PSA */ bookNum: 19, chapterNum: 1, verseNum: 1 };
 
 export default function App() {
-  const editorRef = useRef<EditorRef>(null);
+  const editorRef = useRef<EditorRef>(null!);
   const [scrRef, setScrRef] = useState(defaultScrRef);
 
   setTimeout(() => {
@@ -79,6 +79,18 @@ export default function App() {
   );
 }
 ```
+
+## Features
+
+- USJ editor with USX support
+- Read-only and edit mode
+- Data in but not yet out (coming soon)
+- History - undo & redo
+- Format block type - change `<para>` markers. The current implementation is a proof-of-concept and doesn't have all the markers available yet.
+- BCV linkage - change the book/chapter/verse externally and the cursor moves; move the cursor and it updates the external book/chapter/verse
+- Nodes supported `<book>`, `<chapter>`, `<verse>`, `<para>`, `<char>`, `<note>`, `<ms>`
+- Nodes not yet supported `<table>`, `<row>`, `<cell>`, `<sidebar>`, `<periph>`, `<figure>`, `<optbreak>`, `<ref>`
+- Node options - callback for `<note>` link
 
 ## Demo and Collaborative Web Development Environment
 

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -27,7 +27,7 @@
     "react": ">=18.2.0",
     "react-dom": ">=18.2.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "@lexical/code": "^0.13.1",
     "@lexical/link": "^0.13.1",
     "@lexical/list": "^0.13.1",
@@ -35,9 +35,12 @@
     "@lexical/rich-text": "^0.13.1",
     "@lexical/selection": "^0.13.1",
     "@lexical/utils": "^0.13.1",
+    "fast-equals": "^5.0.1",
+    "lexical": "^0.13.1"
+  },
+  "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
-    "lexical": "^0.13.1",
     "papi-components": "file:./lib/papi-components",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/platform/src/App.tsx
+++ b/packages/platform/src/App.tsx
@@ -1,5 +1,5 @@
 import { RefSelector, ScriptureReference } from "papi-components";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { usxStringToUsj } from "shared/converters/usj/usx-to-usj";
 import { Usj } from "shared/converters/usj/usj.model";
 import { WEB_PSA_USX as usx } from "shared/data/WEB-PSA.usx";
@@ -9,21 +9,27 @@ import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-option
 import { getViewOptions } from "./editor/adaptors/view-options.utils";
 import { formattedViewMode as defaultViewMode } from "./editor/plugins/toolbar/view-mode.model";
 import ViewModeDropDown from "./editor/plugins/toolbar/ViewModeDropDown";
-import Editor from "./editor/Editor";
+import Editor, { EditorRef } from "./editor/Editor";
 import "./App.css";
 
+const defaultUsj = usxStringToUsj('<usx version="3.0" />');
 const defaultScrRef: ScriptureReference = { /* PSA */ bookNum: 19, chapterNum: 1, verseNum: 1 };
-
-const usj = usxStringToUsj(usx);
-
 const nodeOptions: UsjNodeOptions = { [immutableNoteCallerNodeName]: { onClick: () => undefined } };
 
-const onChange = (usj: Usj) => console.log({ usj });
-
 export default function App() {
+  const editorRef = useRef<EditorRef>(null);
   const [viewMode, setViewMode] = useState(defaultViewMode);
   const [scrRef, setScrRef] = useState(defaultScrRef);
   const viewOptions = useMemo(() => getViewOptions(viewMode), [viewMode]);
+
+  setTimeout(() => {
+    editorRef.current?.setUsj(usxStringToUsj(usx));
+  }, 1000);
+
+  const onChange = useCallback((usj: Usj) => {
+    console.log({ usj });
+    editorRef.current?.setUsj(usj);
+  }, []);
 
   return (
     <>
@@ -32,7 +38,8 @@ export default function App() {
       </div>
       <ViewModeDropDown viewMode={viewMode} handleSelect={setViewMode} />
       <Editor
-        usj={usj}
+        defaultUsj={defaultUsj}
+        ref={editorRef}
         viewOptions={viewOptions}
         scrRef={scrRef}
         setScrRef={setScrRef}

--- a/packages/platform/src/App.tsx
+++ b/packages/platform/src/App.tsx
@@ -17,7 +17,9 @@ const defaultScrRef: ScriptureReference = { /* PSA */ bookNum: 19, chapterNum: 1
 const nodeOptions: UsjNodeOptions = { [immutableNoteCallerNodeName]: { onClick: () => undefined } };
 
 export default function App() {
-  const editorRef = useRef<EditorRef>(null);
+  // This ref becomes defined when passed to the editor.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const editorRef = useRef<EditorRef>(null!);
   const [viewMode, setViewMode] = useState(defaultViewMode);
   const [scrRef, setScrRef] = useState(defaultScrRef);
   const viewOptions = useMemo(() => getViewOptions(viewMode), [viewMode]);

--- a/packages/platform/src/editor/adaptors/editor-usj-adaptor.test.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj-adaptor.test.ts
@@ -1,3 +1,4 @@
+import { deepEqual } from "fast-equals";
 import { createEditor } from "lexical";
 import {
   CHAPTER_1_INDEX,
@@ -16,10 +17,11 @@ import { MarkerObject } from "shared/converters/usj/usj.model";
 import scriptureUsjNodes from "shared/nodes/scripture/usj";
 import { CHAPTER_MARKER, SerializedChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
 import { SerializedParaNode } from "shared/nodes/scripture/usj/ParaNode";
+import { getVisibleOpenMarkerText } from "shared/nodes/scripture/usj/node.utils";
 import { SerializedVerseNode, VERSE_MARKER } from "shared/nodes/scripture/usj/VerseNode";
 import { ImmutableNoteCallerNode } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
 import editorUsjAdaptor from "./editor-usj.adaptor";
-import { getVisibleOpenMarkerText } from "shared/nodes/scripture/usj/node.utils";
+import usjEditorAdaptor from "./usj-editor.adaptor";
 
 const testConfig = {
   namespace: "TestEditor",
@@ -75,5 +77,16 @@ describe("Editor USJ Adaptor", () => {
     )[VERSE_2_INDEX];
     usjVerse2.number = verse2Number;
     expect(usj).toEqual(usjGen1v1Edited);
+  });
+
+  it("should convert USJ to Lexical editor state JSON and back again", () => {
+    const serializedEditorState = usjEditorAdaptor.serializeEditorState(usjGen1v1);
+    const editorState = editor.parseEditorState(serializedEditorState);
+
+    const usj = editorUsjAdaptor.deserializeEditorState(editorState);
+
+    const isEqual = deepEqual(usj, usjGen1v1);
+    expect(usj).toEqual(usjGen1v1);
+    expect(isEqual).toBe(true);
   });
 });

--- a/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
@@ -77,16 +77,22 @@ export function deserializeEditorState(editorState: EditorState): Usj | undefine
   return usj;
 }
 
+function removeUndefinedProperties<T>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj as Partial<T>).filter(([_, value]) => value !== undefined),
+  ) as T;
+}
+
 function createBookMarker(node: SerializedBookNode): MarkerObject {
   const { type, marker, code, text } = node;
   let content: MarkerContent[] | undefined;
   if (text) content = [text];
-  return {
+  return removeUndefinedProperties({
     type,
     marker,
     code,
     content,
-  };
+  });
 }
 
 function parseNumberFromText(marker: string, text: string | undefined, number: string): string {
@@ -105,14 +111,14 @@ function createChapterMarker(
   const { text } = node as SerializedChapterNode;
   let { number } = node;
   number = parseNumberFromText(marker, text, number);
-  return {
+  return removeUndefinedProperties({
     type: ChapterNode.getType(),
     marker,
     number,
     sid,
     altnumber,
     pubnumber,
-  };
+  });
 }
 
 function createVerseMarker(node: SerializedImmutableVerseNode | SerializedVerseNode): MarkerObject {
@@ -120,25 +126,25 @@ function createVerseMarker(node: SerializedImmutableVerseNode | SerializedVerseN
   const { text } = node as SerializedVerseNode;
   let { number } = node;
   number = parseNumberFromText(marker, text, number);
-  return {
+  return removeUndefinedProperties({
     type: VerseNode.getType(),
     marker,
     number,
     sid,
     altnumber,
     pubnumber,
-  };
+  });
 }
 
 function createCharMarker(node: SerializedCharNode): MarkerObject {
   const { type, marker } = node;
   let { text } = node;
   if (text.startsWith(NBSP)) text = text.slice(1);
-  return {
+  return removeUndefinedProperties({
     type,
     marker,
     content: [text],
-  };
+  });
 }
 
 function createParaMarker(
@@ -146,11 +152,13 @@ function createParaMarker(
   content: MarkerContent[] | undefined,
 ): MarkerObject {
   const { type, marker } = node;
-  return {
+  // Ensure empty arrays are removed.
+  const _content = content && content.length > 0 ? content : undefined;
+  return removeUndefinedProperties({
     type,
     marker,
-    content,
-  };
+    content: _content,
+  });
 }
 
 function createNoteMarker(
@@ -158,23 +166,25 @@ function createNoteMarker(
   content: MarkerContent[] | undefined,
 ): MarkerObject {
   const { type, marker, caller, category } = node;
-  return {
+  // Ensure empty arrays are removed.
+  const _content = content && content.length > 0 ? content : undefined;
+  return removeUndefinedProperties({
     type,
     marker,
     caller,
     category,
-    content,
-  };
+    content: _content,
+  });
 }
 
 function createMilestoneMarker(node: SerializedMilestoneNode): MarkerObject {
   const { type, marker, sid, eid } = node;
-  return {
+  return removeUndefinedProperties({
     type,
     marker,
     sid,
     eid,
-  };
+  });
 }
 
 function createTextMarker(node: SerializedTextNode): string {

--- a/packages/platform/src/editor/use-deferred-state.hook.ts
+++ b/packages/platform/src/editor/use-deferred-state.hook.ts
@@ -1,0 +1,25 @@
+import { deepEqual } from "fast-equals";
+import { useEffect, useState } from "react";
+
+type UseDeferredStateReturn<T> = [T, T, React.Dispatch<React.SetStateAction<T>>];
+
+/**
+ * `useDeferredState` is a custom hook that lets you defer updating part of the UI.
+ * The `deferred` value is only updated if the changed `incoming` value is different than the
+ * `modified` value.
+ * @param incoming - Incoming value to watch for changes.
+ * @returns Returns the `deferred` value, the `modified` value, and a function to update the
+ *   modified value.
+ */
+export default function useDeferredState<T>(incoming: T): UseDeferredStateReturn<T> {
+  const [deferred, setDeferred] = useState<T>(incoming);
+  const [modified, setModified] = useState<T>(incoming);
+
+  useEffect(() => {
+    if (!deepEqual(incoming, modified)) setDeferred(incoming);
+    // Intentionally ignoring changes to `modified`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [incoming]);
+
+  return [deferred, modified, setModified];
+}

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -1,4 +1,4 @@
-export { default as Editor } from "./editor/Editor";
+export { default as Editor, type EditorRef } from "./editor/Editor";
 export { type Usj } from "shared/converters/usj/usj.model";
 export { usxStringToUsj } from "shared/converters/usj/usx-to-usj";
 export { usjToUsxString } from "shared/converters/usj/usj-to-usx";

--- a/packages/shared-react/plugins/UpdateStatePlugin.tsx
+++ b/packages/shared-react/plugins/UpdateStatePlugin.tsx
@@ -34,11 +34,12 @@ export default function UpdateStatePlugin<TLogger extends LoggerBasic>({
     const serializedEditorState = editorAdaptor.serializeEditorState(scripture, viewOptions);
     const editorState = editor.parseEditorState(serializedEditorState);
     // Execute after the current render cycle.
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       editor.setEditorState(editorState);
       editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
     }, 0);
-  }, [editor, scripture, viewOptions, logger, editorAdaptor]);
+    return () => clearTimeout(timeoutId);
+  }, [editor, scripture, viewOptions, editorAdaptor]);
 
   return null;
 }

--- a/packages/shared/converters/usj/converter-test.data.ts
+++ b/packages/shared/converters/usj/converter-test.data.ts
@@ -3,7 +3,7 @@ import { Usj } from "./usj.model";
 import { NBSP } from "../../nodes/scripture/usj/node.utils";
 import { SerializedParaNode } from "../../nodes/scripture/usj/ParaNode";
 
-export const usxEmpty = '<usx version="3.0"/>';
+export const usxEmpty = '<usx version="3.0" />';
 
 /**
  * Reformatted from:
@@ -18,6 +18,7 @@ export const usxGen1v1 = `
       <verse style="v" number="2" sid="GEN 1:2" />the second verse <verse eid="GEN 1:2" />
       <verse style="v" number="15" sid="GEN 1:15"/>Tell the Israelites that I, the <char style="nd">Lord</char>, the God of their ancestors, the God of Abraham, Isaac, and Jacob,<verse eid="GEN 1:15" />
     </para>
+    <para style="b" />
     <para style="q2"><verse style="v" number="16" sid="GEN 1:16"/>“There is no help for him in God.”<note style="f" caller="+"><char style="fr">3:2 </char><char style="ft">The Hebrew word rendered “God” is “אֱלֹהִ֑ים” (Elohim).</char></note> <char style="qs">Selah.</char><verse eid="GEN 1:16" /></para>
   <chapter eid="GEN 1" />
 </usx>
@@ -37,7 +38,7 @@ export const usxGen1v1ImpliedPara = `
 export const usjEmpty: Usj = { type: "USJ", version: "0.2.1", content: [] };
 
 /** para index where the note exists */
-export const NOTE_PARA_INDEX = 3;
+export const NOTE_PARA_INDEX = 4;
 /** index of the note in para children */
 export const NOTE_INDEX = 2;
 /** index of the note caller in note children */
@@ -78,6 +79,7 @@ export const usjGen1v1: Usj = {
         ", the God of their ancestors, the God of Abraham, Isaac, and Jacob,",
       ],
     },
+    { type: "para", marker: "b" },
     {
       type: "para",
       marker: "q2",
@@ -223,6 +225,16 @@ export const editorStateGen1v1 = {
             version: 1,
           },
         ],
+      },
+      {
+        type: "para",
+        marker: "b",
+        classList: [],
+        direction: null,
+        format: "",
+        indent: 0,
+        version: 1,
+        children: [],
       },
       {
         type: "para",
@@ -455,6 +467,37 @@ export const editorStateGen1v1Editable = {
           {
             type: "text",
             text: ", the God of their ancestors, the God of Abraham, Isaac, and Jacob,",
+            detail: 0,
+            format: 0,
+            mode: "normal",
+            style: "",
+            version: 1,
+          },
+        ],
+      },
+      {
+        type: "para",
+        marker: "b",
+        classList: ["no-indent", "plain-font"],
+        direction: null,
+        format: "",
+        indent: 0,
+        version: 1,
+        children: [
+          {
+            type: "marker",
+            marker: "b",
+            detail: 0,
+            format: 0,
+            isOpening: true,
+            mode: "normal",
+            style: "",
+            text: "",
+            version: 1,
+          },
+          {
+            type: "text",
+            text: NBSP,
             detail: 0,
             format: 0,
             mode: "normal",

--- a/packages/shared/converters/usj/usj-to-usx.test.ts
+++ b/packages/shared/converters/usj/usj-to-usx.test.ts
@@ -7,16 +7,17 @@ import {
   usxGen1v1ImpliedPara,
 } from "./converter-test.data";
 import { usjToUsxString } from "./usj-to-usx";
+import { usxStringToUsj } from "./usx-to-usj";
 
-const SELF_CLOSING_ELEMENT_WHITESPACE = /"\s+\/>/g;
-const INTER_ELEMENT_WHITESPACE = />\s{2,}</g;
-const LAST_ELEMENT_WHITESPACE = />\s+<\/usx>/g;
+const SELF_CLOSING_ELEMENT_WHITESPACE = /(?!")\s+(?=\/>)/g;
+const INTER_ELEMENT_WHITESPACE = /(?!>)\s{2,}(?=<)/g;
+const LAST_ELEMENT_WHITESPACE = /(?!>)\s+(?=<\/usx>)/g;
 
 function removeXmlWhitespace(xml: string): string {
   return xml
-    .replaceAll(SELF_CLOSING_ELEMENT_WHITESPACE, '"/>')
-    .replaceAll(INTER_ELEMENT_WHITESPACE, "><")
-    .replaceAll(LAST_ELEMENT_WHITESPACE, "></usx>")
+    .replaceAll(SELF_CLOSING_ELEMENT_WHITESPACE, "")
+    .replaceAll(INTER_ELEMENT_WHITESPACE, "")
+    .replaceAll(LAST_ELEMENT_WHITESPACE, "")
     .trim();
 }
 
@@ -34,5 +35,11 @@ describe("USJ to USX Converter", () => {
   it("should convert from USJ with implied paragraphs to USX", () => {
     const usx = usjToUsxString(usjGen1v1ImpliedPara);
     expect(usx).toEqual(removeXmlWhitespace(usxGen1v1ImpliedPara));
+  });
+
+  it("should convert from USJ to USX and back", () => {
+    const usx = usjToUsxString(usjGen1v1);
+    const usj = usxStringToUsj(usx);
+    expect(usj).toEqual(usjGen1v1);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,7 @@ importers:
         version: link:../shared
 
   packages/platform:
-    devDependencies:
+    dependencies:
       '@lexical/code':
         specifier: ^0.13.1
         version: 0.13.1(lexical@0.13.1)
@@ -192,15 +192,19 @@ importers:
       '@lexical/utils':
         specifier: ^0.13.1
         version: 0.13.1(lexical@0.13.1)
+      fast-equals:
+        specifier: ^5.0.1
+        version: 5.0.1
+      lexical:
+        specifier: ^0.13.1
+        version: 0.13.1
+    devDependencies:
       '@types/react':
         specifier: ^18.2.48
         version: 18.2.48
       '@types/react-dom':
         specifier: ^18.2.18
         version: 18.2.18
-      lexical:
-        specifier: ^0.13.1
-        version: 0.13.1
       papi-components:
         specifier: file:./lib/papi-components
         version: file:packages/platform/lib/papi-components(@emotion/react@11.11.1)(@emotion/styled@11.11.0)(@mui/material@5.14.18)(react-data-grid@7.0.0-beta.41)(react-dom@18.2.0)(react@18.2.0)
@@ -2352,6 +2356,7 @@ packages:
       '@lexical/selection': 0.13.1(lexical@0.13.1)
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/code@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-QK77r3QgEtJy96ahYXNgpve8EY64BQgBSnPDOuqVrLdl92nPzjqzlsko2OZldlrt7gjXcfl9nqfhZ/CAhStfOg==}
@@ -2361,6 +2366,7 @@ packages:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
       prismjs: 1.29.0
+    dev: false
 
   /@lexical/dragon@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-aNlqfif4//jW7gOxbBgdrbDovU6m3EwQrUw+Y/vqRkY+sWmloyAUeNwCPH1QP3Q5cvfolzOeN5igfBljsFr+1g==}
@@ -2368,6 +2374,7 @@ packages:
       lexical: 0.13.1
     dependencies:
       lexical: 0.13.1
+    dev: false
 
   /@lexical/hashtag@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-Dl0dUG4ZXNjYYuAUR0GMGpLGsA+cps2/ln3xEmy28bZR0sKkjXugsu2QOIxZjYIPBewDrXzPcvK8md45cMYoSg==}
@@ -2376,6 +2383,7 @@ packages:
     dependencies:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/headless@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-W2mLUuWPrsyf2n73NWM8nKiBI11lEpVVzKE0OzMsjTskv5+AAMaeu1wQ7M1508vKdCcUZwA6AOh3To/hstLEpw==}
@@ -2392,6 +2400,7 @@ packages:
     dependencies:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/html@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-XkZrnCSHIUavtpMol6aG8YsJ5KqC9hMxEhAENf3HTGi3ocysCByyXOyt1EhEYpjJvgDG4wRqt25xGDbLjj1/sA==}
@@ -2401,6 +2410,7 @@ packages:
       '@lexical/selection': 0.13.1(lexical@0.13.1)
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/link@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-7E3B2juL2UoMj2n+CiyFZ7tlpsdViAoIE7MpegXwfe/VQ66wFwk/VxGTa/69ng2EoF7E0kh+SldvGQDrWAWb1g==}
@@ -2409,6 +2419,7 @@ packages:
     dependencies:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/list@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-6U1pmNZcKLuOWiWRML8Raf9zSEuUCMlsOye82niyF6I0rpPgYo5UFghAAbGISDsyqzM1B2L4BgJ6XrCk/dJptg==}
@@ -2417,6 +2428,7 @@ packages:
     dependencies:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/mark@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-dW27PW8wWDOKFqXTBUuUfV+umU0KfwvXGkPUAxRJrvwUWk5RKaS48LhgbNlQ5BfT84Q8dSiQzvbaa6T40t9a3A==}
@@ -2425,6 +2437,7 @@ packages:
     dependencies:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/markdown@0.13.1(@lexical/clipboard@0.13.1)(@lexical/selection@0.13.1)(lexical@0.13.1):
     resolution: {integrity: sha512-6tbdme2h5Zy/M88loVQVH5G0Nt7VMR9UUkyiSaicyBRDOU2OHacaXEp+KSS/XuF+d7TA+v/SzyDq8HS77cO1wA==}
@@ -2441,6 +2454,7 @@ packages:
     transitivePeerDependencies:
       - '@lexical/clipboard'
       - '@lexical/selection'
+    dev: false
 
   /@lexical/offset@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-j/RZcztJ7dyTrfA2+C3yXDzWDXV+XmMpD5BYeQCEApaHvlo20PHt1BISk7RcrnQW8PdzGvpKblRWf//c08LS9w==}
@@ -2448,6 +2462,7 @@ packages:
       lexical: 0.13.1
     dependencies:
       lexical: 0.13.1
+    dev: false
 
   /@lexical/overflow@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-Uw34j+qG2UJRCIR+bykfFMduFk7Pc4r/kNt8N1rjxGuGXAsreTVch1iOhu7Ev6tJgkURsduKuaJCAi7iHnKl7g==}
@@ -2455,6 +2470,7 @@ packages:
       lexical: 0.13.1
     dependencies:
       lexical: 0.13.1
+    dev: false
 
   /@lexical/plain-text@0.13.1(@lexical/clipboard@0.13.1)(@lexical/selection@0.13.1)(@lexical/utils@0.13.1)(lexical@0.13.1):
     resolution: {integrity: sha512-4j5KAsMKUvJ8LhVDSS4zczbYXzdfmgYSAVhmqpSnJtud425Nk0TAfpUBLFoivxZB7KMoT1LGWQZvd47IvJPvtA==}
@@ -2468,6 +2484,7 @@ packages:
       '@lexical/selection': 0.13.1(lexical@0.13.1)
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/react@0.13.1(lexical@0.13.1)(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.8):
     resolution: {integrity: sha512-Sy6EL230KAb0RZsZf1dZrRrc3+rvCDQWltcd8C/cqBUYlxsLYCW9s4f3RB2werngD/PtLYbBB48SYXNkIALITA==}
@@ -2499,6 +2516,7 @@ packages:
       react-error-boundary: 3.1.4(react@18.2.0)
     transitivePeerDependencies:
       - yjs
+    dev: false
 
   /@lexical/rich-text@0.13.1(@lexical/clipboard@0.13.1)(@lexical/selection@0.13.1)(@lexical/utils@0.13.1)(lexical@0.13.1):
     resolution: {integrity: sha512-HliB9Ync06mv9DBg/5j0lIsTJp+exLHlaLJe+n8Zq1QNTzZzu2LsIT/Crquk50In7K/cjtlaQ/d5RB0LkjMHYg==}
@@ -2512,6 +2530,7 @@ packages:
       '@lexical/selection': 0.13.1(lexical@0.13.1)
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/selection@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-Kt9eSwjxPznj7yzIYipu9yYEgmRJhHiq3DNxHRxInYcZJWWNNHum2xKyxwwcN8QYBBzgfPegfM/geqQEJSV1lQ==}
@@ -2519,6 +2538,7 @@ packages:
       lexical: 0.13.1
     dependencies:
       lexical: 0.13.1
+    dev: false
 
   /@lexical/table@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-VQzgkfkEmnvn6C64O/kvl0HI3bFoBh3WA/U67ALw+DS11Mb5CKjbt0Gzm/258/reIxNMpshjjicpWMv9Miwauw==}
@@ -2527,6 +2547,7 @@ packages:
     dependencies:
       '@lexical/utils': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/text@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-NYy3TZKt3qzReDwN2Rr5RxyFlg84JjXP2JQGMrXSSN7wYe73ysQIU6PqdVrz4iZkP+w34F3pl55dJ24ei3An9w==}
@@ -2534,6 +2555,7 @@ packages:
       lexical: 0.13.1
     dependencies:
       lexical: 0.13.1
+    dev: false
 
   /@lexical/utils@0.13.1(lexical@0.13.1):
     resolution: {integrity: sha512-AtQQKzYymkbOaQxaBXjRBS8IPxF9zWQnqwHTUTrJqJ4hX71aIQd/thqZbfQETAFJfC8pNBZw5zpxN6yPHk23dQ==}
@@ -2544,6 +2566,7 @@ packages:
       '@lexical/selection': 0.13.1(lexical@0.13.1)
       '@lexical/table': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
+    dev: false
 
   /@lexical/yjs@0.13.1(lexical@0.13.1)(yjs@13.6.8):
     resolution: {integrity: sha512-4GbqQM+PwNTV59AZoNrfTe/0rLjs+cX6Y6yAdZSRPBwr5L3JzYeU1TTcFCVQTtsE7KF8ddVP8sD7w9pi8rOWLA==}
@@ -2554,6 +2577,7 @@ packages:
       '@lexical/offset': 0.13.1(lexical@0.13.1)
       lexical: 0.13.1
       yjs: 13.6.8
+    dev: false
 
   /@microsoft/api-extractor-model@7.28.3(@types/node@18.19.18):
     resolution: {integrity: sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==}
@@ -6121,6 +6145,11 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  /fast-equals@5.0.1:
+    resolution: {integrity: sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
   /fast-glob@3.2.7:
     resolution: {integrity: sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==}
     engines: {node: '>=8'}
@@ -6928,6 +6957,7 @@ packages:
 
   /isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+    dev: false
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -7673,6 +7703,7 @@ packages:
 
   /lexical@0.13.1:
     resolution: {integrity: sha512-jaqRYzVEfBKbX4FwYpd/g+MyOjRaraAel0iQsTrwvx3hyN0bswUZuzb6H6nGlFSjcdrc77wKpyKwoWj4aUd+Bw==}
+    dev: false
 
   /lib0@0.2.86:
     resolution: {integrity: sha512-kxigQTM4Q7NwJkEgdqQvU21qiR37twcqqLmh+/SbiGbRLfPlLVbHyY9sWp7PwXh0Xus9ELDSjsUOwcrdt5yZ4w==}
@@ -7680,6 +7711,7 @@ packages:
     hasBin: true
     dependencies:
       isomorphic.js: 0.2.5
+    dev: false
 
   /lilconfig@3.0.0:
     resolution: {integrity: sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==}
@@ -8504,6 +8536,7 @@ packages:
   /prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
     engines: {node: '>=6'}
+    dev: false
 
   /proc-log@3.0.0:
     resolution: {integrity: sha512-++Vn7NS4Xf9NacaU9Xq3URUuqZETPsf8L4j5/ckhaRYsfPeRyzGw+iDjFhV/Jr3uNmTvvddEJFWh5R1gRgUH8A==}
@@ -8646,6 +8679,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.2
       react: 18.2.0
+    dev: false
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -10241,6 +10275,7 @@ packages:
     engines: {node: '>=16.0.0', npm: '>=8.0.0'}
     dependencies:
       lib0: 0.2.86
+    dev: false
 
   /yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}


### PR DESCRIPTION
- defer USJ updates to platform editor.
- fix round trip.
  - removed properties that are undefined.
  - remove empty content arrays.
- also move `lexical` to dependencies (no longer - bundled in editor package) .
- also clear timeout on `UpdateStatePlugin` exit.
- fixes #44.