### PR TITLE
allow `viewOptions` to be actually optional

### DIFF
--- a/packages/platform/src/App.tsx
+++ b/packages/platform/src/App.tsx
@@ -6,8 +6,7 @@ import { WEB_PSA_USX as usx } from "shared/data/WEB-PSA.usx";
 // import { PSA_USX as usx } from "shared/data/psa.usfm.usx";
 import { immutableNoteCallerNodeName } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
-import { getViewOptions } from "./editor/adaptors/view-options.utils";
-import { formattedViewMode as defaultViewMode } from "./editor/toolbar/view-mode.model";
+import { getViewOptions, DEFAULT_VIEW_MODE } from "./editor/adaptors/view-options.utils";
 import ViewModeDropDown from "./editor/toolbar/ViewModeDropDown";
 import Editor, { EditorRef } from "./editor/Editor";
 import "./App.css";
@@ -20,7 +19,7 @@ export default function App() {
   // This ref becomes defined when passed to the editor.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const editorRef = useRef<EditorRef>(null!);
-  const [viewMode, setViewMode] = useState(defaultViewMode);
+  const [viewMode, setViewMode] = useState(DEFAULT_VIEW_MODE);
   const [scrRef, setScrRef] = useState(defaultScrRef);
   const viewOptions = useMemo(() => getViewOptions(viewMode), [viewMode]);
 

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -18,7 +18,7 @@ import {
   removeNodeAndAfter,
   removeNodesBeforeNode,
 } from "shared/nodes/scripture/usj/node.utils";
-import { ViewOptions } from "./adaptors/view-options.utils";
+import { ViewOptions, getViewOptions } from "./adaptors/view-options.utils";
 import { getChapterNodeClass, getVerseNodeClass } from "./adaptors/usj-editor.adaptor";
 
 /** Prevents the cursor being moved again after a selection has changed. */
@@ -34,7 +34,7 @@ let hasSelectionChanged = false;
 export default function ScriptureReferencePlugin({
   scrRef,
   setScrRef,
-  viewOptions,
+  viewOptions = getViewOptions(),
 }: {
   scrRef: ScriptureReference;
   setScrRef: (scrRef: ScriptureReference) => void;

--- a/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
@@ -20,7 +20,7 @@ import { MarkerObject } from "shared/converters/usj/usj.model";
 import { SerializedParaNode } from "shared/nodes/scripture/usj/ParaNode";
 import { SerializedNoteNode } from "shared/nodes/scripture/usj/NoteNode";
 import { SerializedImmutableNoteCallerNode } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
-import { unformattedViewMode } from "../toolbar/view-mode.model";
+import { UNFORMATTED_VIEW_MODE } from "../toolbar/view-mode.model";
 import { serializeEditorState, reset } from "./usj-editor.adaptor";
 import { getViewOptions } from "./view-options.utils";
 
@@ -68,7 +68,7 @@ describe("USJ Editor Adaptor", () => {
   it("should convert from USJ to Lexical editor state JSON with editable view", () => {
     const serializedEditorState = serializeEditorState(
       usjGen1v1,
-      getViewOptions(unformattedViewMode),
+      getViewOptions(UNFORMATTED_VIEW_MODE),
     );
 
     expect(serializedEditorState).toEqual(editorStateGen1v1Editable);

--- a/packages/platform/src/editor/adaptors/view-options.utils.ts
+++ b/packages/platform/src/editor/adaptors/view-options.utils.ts
@@ -20,7 +20,7 @@ export type ViewOptions = {
  * @returns the view options if the view exists, the default options if the viewMode is undefined,
  *   `undefined` otherwise.
  */
-export function getViewOptions(viewMode: string | undefined): ViewOptions | undefined {
+export function getViewOptions(viewMode?: string | undefined): ViewOptions | undefined {
   let viewOptions: ViewOptions | undefined;
   switch (viewMode ?? defaultViewMode) {
     case formattedViewMode:

--- a/packages/platform/src/editor/adaptors/view-options.utils.ts
+++ b/packages/platform/src/editor/adaptors/view-options.utils.ts
@@ -1,9 +1,4 @@
-import {
-  ViewMode,
-  formattedViewMode as defaultViewMode,
-  formattedViewMode,
-  unformattedViewMode,
-} from "../toolbar/view-mode.model";
+import { ViewMode, FORMATTED_VIEW_MODE, UNFORMATTED_VIEW_MODE } from "../toolbar/view-mode.model";
 
 export type ViewOptions = {
   /** USFM markers are visible, editable or hidden */
@@ -14,6 +9,8 @@ export type ViewOptions = {
   isFormattedFont: boolean;
 };
 
+export const DEFAULT_VIEW_MODE = FORMATTED_VIEW_MODE;
+
 /**
  * Get view option properties based on the view mode.
  * @param viewMode - View mode of the editor.
@@ -22,15 +19,15 @@ export type ViewOptions = {
  */
 export function getViewOptions(viewMode?: string | undefined): ViewOptions | undefined {
   let viewOptions: ViewOptions | undefined;
-  switch (viewMode ?? defaultViewMode) {
-    case formattedViewMode:
+  switch (viewMode ?? DEFAULT_VIEW_MODE) {
+    case FORMATTED_VIEW_MODE:
       viewOptions = {
         markerMode: "hidden",
         hasSpacing: true,
         isFormattedFont: true,
       };
       break;
-    case unformattedViewMode:
+    case UNFORMATTED_VIEW_MODE:
       viewOptions = {
         markerMode: "editable",
         hasSpacing: false,
@@ -52,7 +49,7 @@ export function viewOptionsToMode(viewOptions: ViewOptions | undefined): ViewMod
   if (!viewOptions) return undefined;
 
   const { markerMode, hasSpacing, isFormattedFont } = viewOptions;
-  if (markerMode === "hidden" && hasSpacing && isFormattedFont) return formattedViewMode;
-  if (markerMode === "editable" && !hasSpacing && !isFormattedFont) return unformattedViewMode;
+  if (markerMode === "hidden" && hasSpacing && isFormattedFont) return FORMATTED_VIEW_MODE;
+  if (markerMode === "editable" && !hasSpacing && !isFormattedFont) return UNFORMATTED_VIEW_MODE;
   return undefined;
 }

--- a/packages/platform/src/editor/toolbar/view-mode.model.ts
+++ b/packages/platform/src/editor/toolbar/view-mode.model.ts
@@ -1,9 +1,9 @@
 export type ViewNameKey = keyof typeof viewModeToViewNames;
 export type ViewMode = ViewNameKey;
 
-export const formattedViewMode = "formatted";
-export const unformattedViewMode = "unformatted";
+export const FORMATTED_VIEW_MODE = "formatted";
+export const UNFORMATTED_VIEW_MODE = "unformatted";
 export const viewModeToViewNames = {
-  [formattedViewMode]: "Formatted",
-  [unformattedViewMode]: "Unformatted",
+  [FORMATTED_VIEW_MODE]: "Formatted",
+  [UNFORMATTED_VIEW_MODE]: "Unformatted",
 };

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -6,6 +6,7 @@ export { immutableNoteCallerNodeName } from "shared-react/nodes/scripture/usj/Im
 export { type UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 export {
   type ViewOptions,
+  DEFAULT_VIEW_MODE,
   getViewOptions,
   viewOptionsToMode,
 } from "./editor/adaptors/view-options.utils";


### PR DESCRIPTION
- fixes #68
- fix view mode consts to be UPPER_CAMEL case
- also export `DEFAULT_VIEW_MODE`