### PR TITLE
Scribe cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ graph TB
   V(perf-vanilla) --> S(shared)
   R(perf-react) --> S
   P(platform) --> SR
+  SB(scribe) --> SR
   SR(shared-react) --> S
   P --> S
+  SB --> S
 ```
 
 <a alt="Nx logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="45"></a>

--- a/packages/scribe/package.json
+++ b/packages/scribe/package.json
@@ -42,7 +42,6 @@
     "prettier-plugin-tailwindcss": "^0.5.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "platform": "link:../platform",
     "shared": "link:../shared",
     "shared-react": "link:../shared-react",
     "sj-usfm-grammar": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,9 +261,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.0
         version: 18.3.0
-      platform:
-        specifier: link:../platform
-        version: link:../platform
       postcss:
         specifier: ^8.4.35
         version: 8.4.38


### PR DESCRIPTION
- remove `platform` dependency
- add Scribe to the README structure graph