### PR TITLE
Platform comment tidy up

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -64,6 +64,7 @@ export type EditorRef = {
    * @param id - ID of the annotation.
    */
   removeAnnotation(type: string, id: string): void;
+  toolbarEndRef: React.RefObject<HTMLElement>;
 };
 
 /** Options to configure the editor. */
@@ -145,6 +146,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
 ): JSX.Element {
   const editorRef = useRef<LexicalEditor | null>(null);
   const annotationRef = useRef<AnnotationRef | null>(null);
+  const toolbarEndRef = useRef<HTMLDivElement>(null);
   const [usj, setUsj] = useState(defaultUsj);
   const [loadedUsj, editedUsj, setEditedUsj] = useDeferredState(usj);
   editorConfig.editable = !options?.isReadonly;
@@ -172,6 +174,9 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
     removeAnnotation(type, id) {
       annotationRef.current?.removeAnnotation(type, id);
     },
+    get toolbarEndRef() {
+      return toolbarEndRef;
+    },
   }));
 
   const handleChange = useCallback(
@@ -189,7 +194,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
   return (
     <LexicalComposer initialConfig={editorConfig}>
       <div className="editor-container">
-        {!options?.isReadonly && <ToolbarPlugin />}
+        {!options?.isReadonly && <ToolbarPlugin ref={toolbarEndRef} />}
         <div className="editor-inner">
           <EditorRefPlugin editorRef={editorRef} />
           <RichTextPlugin

--- a/packages/platform/src/editor/editor.css
+++ b/packages/platform/src/editor/editor.css
@@ -18,6 +18,7 @@
 .editor-inner {
   background: #fff;
   position: relative;
+  display: flex;
 }
 
 .editor-input {
@@ -29,6 +30,7 @@
   outline: 0;
   padding: 15px 10px;
   caret-color: #444;
+  flex: auto;
 }
 
 .editor-placeholder {

--- a/packages/platform/src/editor/toolbar/ToolbarPlugin.tsx
+++ b/packages/platform/src/editor/toolbar/ToolbarPlugin.tsx
@@ -20,7 +20,7 @@ import {
   SELECTION_CHANGE_COMMAND,
   UNDO_COMMAND,
 } from "lexical";
-import { useCallback, useEffect, useState } from "react";
+import { forwardRef, useCallback, useEffect, useState } from "react";
 import { IS_APPLE } from "shared/lexical/environment";
 import { ParaNode } from "shared/nodes/scripture/usj/ParaNode";
 import BlockFormatDropDown from "./BlockFormatDropDown";
@@ -29,7 +29,7 @@ function Divider(): JSX.Element {
   return <div className="divider" />;
 }
 
-export default function ToolbarPlugin(): JSX.Element {
+const ToolbarPlugin = forwardRef<HTMLDivElement>(function ToolbarPlugin(_props, ref): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [activeEditor, setActiveEditor] = useState(editor);
   const [blockMarker, setBlockMarker] = useState("");
@@ -134,6 +134,9 @@ export default function ToolbarPlugin(): JSX.Element {
           <Divider />
         </>
       )}
+      <div ref={ref} className="end-container"></div>
     </div>
   );
-}
+});
+
+export default ToolbarPlugin;

--- a/packages/platform/src/marginal/comments/CommentPlugin.css
+++ b/packages/platform/src/marginal/comments/CommentPlugin.css
@@ -38,12 +38,6 @@ i.add-comment {
   background-image: url("/assets/images/icons/chat-left-text.svg");
 }
 
-@media (max-width: 1024px) {
-  .CommentPlugin_AddCommentBox {
-    display: none;
-  }
-}
-
 .CommentPlugin_CommentInputBox {
   display: block;
   position: absolute;
@@ -141,10 +135,11 @@ i.add-comment {
 }
 
 .CommentPlugin_ShowCommentsButton {
-  position: fixed;
-  top: 10px;
-  right: 10px;
-  background-color: #ddd;
+  padding-top: 6px;
+  padding-bottom: 7px;
+  padding-left: 13px;
+  padding-right: 13px;
+  background-color: inherit;
   border-radius: 10px;
 }
 
@@ -159,12 +154,6 @@ i.comments {
   transition: opacity 0.2s linear;
 }
 
-@media (max-width: 1024px) {
-  .CommentPlugin_ShowCommentsButton {
-    display: none;
-  }
-}
-
 .CommentPlugin_ShowCommentsButton:hover i.comments {
   opacity: 1;
 }
@@ -174,16 +163,12 @@ i.comments {
 }
 
 .CommentPlugin_CommentsPanel {
-  position: fixed;
-  right: 0;
   width: 300px;
-  height: calc(100% - 88px);
-  top: 88px;
+  height: 100%;
   background-color: #fff;
   border-top-left-radius: 10px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   animation: show-comments 0.2s ease;
-  z-index: 25;
 }
 
 @keyframes show-comments {
@@ -273,7 +258,7 @@ i.send {
   top: calc(50% - 15px);
   margin: 0;
   padding: 0;
-  width: 100%;
+  width: inherit;
 }
 
 .CommentPlugin_CommentsPanel_List {
@@ -281,7 +266,7 @@ i.send {
   list-style-type: none;
   margin: 0;
   padding: 0;
-  width: 100%;
+  width: inherit;
   position: absolute;
   top: 45px;
   overflow-y: auto;

--- a/packages/platform/src/marginal/comments/CommentPlugin.tsx
+++ b/packages/platform/src/marginal/comments/CommentPlugin.tsx
@@ -64,10 +64,12 @@ export const INSERT_INLINE_COMMAND: LexicalCommand<void> = createCommand("INSERT
 function AddCommentBox({
   anchorKey,
   editor,
+  showComments,
   onAddComment,
 }: {
   anchorKey: NodeKey;
   editor: LexicalEditor;
+  showComments: boolean;
   onAddComment: () => void;
 }): JSX.Element {
   const boxRef = useRef<HTMLDivElement>(null);
@@ -95,7 +97,7 @@ function AddCommentBox({
 
   useLayoutEffect(() => {
     updatePosition();
-  }, [anchorKey, editor, updatePosition]);
+  }, [anchorKey, editor, showComments, updatePosition]);
 
   return (
     <div className="CommentPlugin_AddCommentBox" ref={boxRef}>
@@ -673,10 +675,14 @@ function useCollabAuthorName(): string {
 export default function CommentPlugin<TLogger extends LoggerBasic>({
   providerFactory,
   setCommentStore,
+  showCommentsContainerRef,
+  commentContainerRef,
   logger,
 }: {
   providerFactory?: (id: string, yjsDocMap: Map<string, Doc>) => Provider;
   setCommentStore?: (commentStore: CommentStore) => void;
+  showCommentsContainerRef?: React.RefObject<HTMLElement> | null;
+  commentContainerRef?: React.RefObject<HTMLElement>;
   logger?: TLogger;
 }): JSX.Element {
   const collabContext = useCollaborationContext();
@@ -926,19 +932,25 @@ export default function CommentPlugin<TLogger extends LoggerBasic>({
         activeAnchorKey !== undefined &&
         !showCommentInput &&
         createPortal(
-          <AddCommentBox anchorKey={activeAnchorKey} editor={editor} onAddComment={onAddComment} />,
+          <AddCommentBox
+            anchorKey={activeAnchorKey}
+            editor={editor}
+            showComments={showComments}
+            onAddComment={onAddComment}
+          />,
           document.body,
         )}
-      {createPortal(
-        <Button
-          className={`CommentPlugin_ShowCommentsButton ${showComments ? "active" : ""}`}
-          onClick={() => setShowComments(!showComments)}
-          title={showComments ? "Hide Comments" : "Show Comments"}
-        >
-          <i className="comments" />
-        </Button>,
-        document.body,
-      )}
+      {showCommentsContainerRef !== null &&
+        createPortal(
+          <Button
+            className={`CommentPlugin_ShowCommentsButton ${showComments ? "active" : ""}`}
+            onClick={() => setShowComments(!showComments)}
+            title={showComments ? "Hide Comments" : "Show Comments"}
+          >
+            <i className="comments" />
+          </Button>,
+          showCommentsContainerRef?.current ?? document.body,
+        )}
       {showComments &&
         createPortal(
           <CommentsPanel
@@ -948,7 +960,7 @@ export default function CommentPlugin<TLogger extends LoggerBasic>({
             activeIDs={activeIDs}
             markNodeMap={markNodeMap}
           />,
-          document.body,
+          commentContainerRef?.current ?? document.body,
         )}
     </>
   );


### PR DESCRIPTION
- always show `AddCommentBox` & `ShowCommentsButton`
- sidebar appears beside text
- move `showComments` to toolbar