### PR TITLE
cleanup

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -236,7 +236,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
           />
           <AnnotationPlugin ref={annotationRef} logger={logger} />
           <NoteNodePlugin nodeOptions={nodeOptions} logger={logger} />
-          <ContextMenuPlugin isReadonly={isReadonly} />
+          <ContextMenuPlugin />
           <ClipboardPlugin />
           {children}
         </div>

--- a/packages/shared-react/plugins/ContextMenuPlugin.tsx
+++ b/packages/shared-react/plugins/ContextMenuPlugin.tsx
@@ -95,12 +95,9 @@ export class ContextMenuOption extends MenuOption {
   }
 }
 
-export default function ContextMenuPlugin({
-  isReadonly = false,
-}: {
-  isReadonly?: boolean;
-}): JSX.Element {
+export default function ContextMenuPlugin(): JSX.Element {
   const [editor] = useLexicalComposerContext();
+  const isReadonly = !editor.isEditable();
   const closeMenuRef = useRef<(() => void) | undefined>();
 
   const options = useMemo(() => {


### PR DESCRIPTION
- `ContextMenuPlugin`: no longer need to pass in `isReadonly` prop.