### PR TITLE
fix #133

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -30,7 +30,8 @@
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
         "jestConfig": "{projectRoot}/jest.config.ts",
-        "passWithNoTests": true
+        "passWithNoTests": true,
+        "silent": true
       },
       "configurations": { "ci": { "ci": true, "codeCoverage": true } }
     },

--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -16,7 +16,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { ScriptureReference } from "platform-bible-react";
+import type { ScriptureReference } from "platform-bible-utils";
 import { TypedMarkNode } from "shared/nodes/features/TypedMarkNode";
 import scriptureUsjNodes from "shared/nodes/scripture/usj";
 import AnnotationPlugin, {
@@ -24,12 +24,12 @@ import AnnotationPlugin, {
   AnnotationRef,
 } from "shared-react/annotation/AnnotationPlugin";
 import { AnnotationRange, SelectionRange } from "shared-react/annotation/selection.model";
-import ClipboardPlugin from "shared-react/plugins/ClipboardPlugin";
-import ContextMenuPlugin from "shared-react/plugins/ContextMenuPlugin";
 import { ImmutableNoteCallerNode } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
 import useDefaultNodeOptions from "shared-react/nodes/scripture/usj/use-default-node-options.hook";
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import { HistoryPlugin } from "shared-react/plugins/HistoryPlugin";
+import ClipboardPlugin from "shared-react/plugins/ClipboardPlugin";
+import ContextMenuPlugin from "shared-react/plugins/ContextMenuPlugin";
 import NoteNodePlugin from "shared-react/plugins/NoteNodePlugin";
 import { LoggerBasic } from "shared-react/plugins/logger-basic.model";
 import UpdateStatePlugin from "shared-react/plugins/UpdateStatePlugin";

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -6,7 +6,7 @@ import {
   COMMAND_PRIORITY_LOW,
   SELECTION_CHANGE_COMMAND,
 } from "lexical";
-import { ScriptureReference } from "platform-bible-react";
+import type { ScriptureReference } from "platform-bible-utils";
 import { useEffect } from "react";
 import { $isBookNode, BookNode } from "shared/nodes/scripture/usj/BookNode";
 import {
@@ -18,8 +18,12 @@ import {
   removeNodeAndAfter,
   removeNodesBeforeNode,
 } from "shared/nodes/scripture/usj/node.utils";
-import { ViewOptions, getViewOptions } from "./adaptors/view-options.utils";
-import { getChapterNodeClass, getVerseNodeClass } from "./adaptors/usj-editor.adaptor";
+import {
+  getChapterNodeClass,
+  getVerseNodeClass,
+  getViewOptions,
+  ViewOptions,
+} from "./adaptors/view-options.utils";
 
 /** Prevents the cursor being moved again after a selection has changed. */
 let hasSelectionChanged = false;

--- a/packages/platform/src/editor/adaptors/editor-usj-adaptor.test.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj-adaptor.test.ts
@@ -1,5 +1,6 @@
 import { MarkerObject } from "@biblionexus-foundation/scripture-utilities";
 import { deepEqual } from "fast-equals";
+import { SerializedTextNode } from "lexical";
 import { TypedMarkNode } from "shared/nodes/features/TypedMarkNode";
 import scriptureUsjNodes from "shared/nodes/scripture/usj";
 import { CHAPTER_MARKER, SerializedChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
@@ -62,7 +63,10 @@ describe("Editor USJ Adaptor", () => {
     const editorStateEdited = editorStateGen1v1Editable;
     const chapter1 = editorStateEdited.root.children[CHAPTER_1_INDEX] as SerializedChapterNode;
     const chapter1Number = "101";
-    chapter1.text = getVisibleOpenMarkerText(CHAPTER_MARKER, chapter1Number);
+    (chapter1.children[0] as SerializedTextNode).text = getVisibleOpenMarkerText(
+      CHAPTER_MARKER,
+      chapter1Number,
+    );
     const verse2 = (editorStateEdited.root.children[VERSE_PARA_INDEX] as SerializedParaNode)
       .children[VERSE_2_EDITABLE_INDEX] as SerializedVerseNode;
     const verse2Number = "202";

--- a/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
@@ -20,7 +20,7 @@ import {
 import {
   NBSP,
   getEditableCallerText,
-  openingMarkerText,
+  parseNumberFromMarkerText,
 } from "shared/nodes/scripture/usj/node.utils";
 import { BookNode, SerializedBookNode } from "shared/nodes/scripture/usj/BookNode";
 import { ChapterNode, SerializedChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
@@ -109,22 +109,27 @@ function createBookMarker(
   });
 }
 
-function parseNumberFromText(marker: string, text: string | undefined, number: string): string {
-  const openMarkerText = openingMarkerText(marker);
-  if (text && text.startsWith(openMarkerText)) {
-    const numberText = parseInt(text.slice(openMarkerText.length), 10);
-    if (!isNaN(numberText)) number = numberText.toString();
-  }
-  return number;
+function createImmutableChapterMarker(node: SerializedImmutableChapterNode): MarkerObject {
+  const { marker, number, sid, altnumber, pubnumber, unknownAttributes } = node;
+  return removeUndefinedProperties({
+    type: ChapterNode.getType(),
+    marker,
+    number,
+    sid,
+    altnumber,
+    pubnumber,
+    ...unknownAttributes,
+  });
 }
 
 function createChapterMarker(
-  node: SerializedImmutableChapterNode | SerializedChapterNode,
+  node: SerializedChapterNode,
+  content: MarkerContent[] | undefined,
 ): MarkerObject {
   const { marker, sid, altnumber, pubnumber, unknownAttributes } = node;
-  const { text } = node as SerializedChapterNode;
+  const text = content && typeof content[0] === "string" ? content[0] : undefined;
   let { number } = node;
-  number = parseNumberFromText(marker, text, number);
+  number = parseNumberFromMarkerText(marker, text, number);
   return removeUndefinedProperties({
     type: ChapterNode.getType(),
     marker,
@@ -140,7 +145,7 @@ function createVerseMarker(node: SerializedImmutableVerseNode | SerializedVerseN
   const { marker, sid, altnumber, pubnumber, unknownAttributes } = node;
   const { text } = node as SerializedVerseNode;
   let { number } = node;
-  number = parseNumberFromText(marker, text, number);
+  number = parseNumberFromMarkerText(marker, text, number);
   return removeUndefinedProperties({
     type: VerseNode.getType(),
     marker,
@@ -313,6 +318,7 @@ function recurseNodes(
   let pids: string[] = [];
   nodes.forEach((node, index) => {
     const serializedBookNode = node as SerializedBookNode;
+    const serializedChapterNode = node as SerializedChapterNode;
     const serializedParaNode = node as SerializedParaNode;
     const serializedNoteNode = node as SerializedNoteNode;
     const serializedTextNode = node as SerializedTextNode;
@@ -325,9 +331,11 @@ function recurseNodes(
         );
         break;
       case ImmutableChapterNode.getType():
+        markers.push(createImmutableChapterMarker(node as SerializedImmutableChapterNode));
+        break;
       case ChapterNode.getType():
         markers.push(
-          createChapterMarker(node as SerializedImmutableChapterNode | SerializedChapterNode),
+          createChapterMarker(serializedChapterNode, recurseNodes(serializedChapterNode.children)),
         );
         break;
       case ImmutableVerseNode.getType():

--- a/packages/platform/src/editor/adaptors/view-options.utils.ts
+++ b/packages/platform/src/editor/adaptors/view-options.utils.ts
@@ -1,3 +1,11 @@
+import { ChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
+import { ImmutableChapterNode } from "shared/nodes/scripture/usj/ImmutableChapterNode";
+import { ImmutableVerseNode } from "shared/nodes/scripture/usj/ImmutableVerseNode";
+import {
+  TEXT_SPACING_CLASS_NAME,
+  FORMATTED_FONT_CLASS_NAME,
+} from "shared/nodes/scripture/usj/node.utils";
+import { VerseNode } from "shared/nodes/scripture/usj/VerseNode";
 import { ViewMode, FORMATTED_VIEW_MODE, UNFORMATTED_VIEW_MODE } from "../toolbar/view-mode.model";
 
 export type ViewOptions = {
@@ -52,4 +60,38 @@ export function viewOptionsToMode(viewOptions: ViewOptions | undefined): ViewMod
   if (markerMode === "hidden" && hasSpacing && isFormattedFont) return FORMATTED_VIEW_MODE;
   if (markerMode === "editable" && !hasSpacing && !isFormattedFont) return UNFORMATTED_VIEW_MODE;
   return undefined;
+}
+
+/**
+ * Get the chapter node class for the given view options.
+ * @param viewOptions - View options of the editor.
+ * @returns the chapter node class if the view is defined, `undefined` otherwise.
+ */
+export function getChapterNodeClass(viewOptions: ViewOptions | undefined) {
+  if (!viewOptions) return;
+
+  return viewOptions.markerMode === "editable" ? ChapterNode : ImmutableChapterNode;
+}
+
+/**
+ * Get the verse node class for the given view options.
+ * @param viewOptions - View options of the editor.
+ * @returns the verse node class if the view is defined, `undefined` otherwise.
+ */
+export function getVerseNodeClass(viewOptions: ViewOptions | undefined) {
+  if (!viewOptions) return;
+
+  return viewOptions.markerMode === "editable" ? VerseNode : ImmutableVerseNode;
+}
+
+/**
+ * Get the class list for an element node.
+ * @param viewOptions - View options of the editor.
+ * @returns the element class list based on view options.
+ */
+export function getClassList(viewOptions: ViewOptions | undefined) {
+  const classList: string[] = [];
+  if (viewOptions?.hasSpacing) classList.push(TEXT_SPACING_CLASS_NAME);
+  if (viewOptions?.isFormattedFont) classList.push(FORMATTED_FONT_CLASS_NAME);
+  return classList;
 }

--- a/packages/platform/src/marginal/comments/CommentPlugin.tsx
+++ b/packages/platform/src/marginal/comments/CommentPlugin.tsx
@@ -26,6 +26,7 @@ import {
   $isTextNode,
   CLEAR_EDITOR_COMMAND,
   COMMAND_PRIORITY_EDITOR,
+  COMMAND_PRIORITY_NORMAL,
   createCommand,
   KEY_ESCAPE_COMMAND,
 } from "lexical";
@@ -117,7 +118,7 @@ function EscapeHandlerPlugin({ onEscape }: { onEscape: (e: KeyboardEvent) => boo
       (event: KeyboardEvent) => {
         return onEscape(event);
       },
-      2,
+      COMMAND_PRIORITY_NORMAL,
     );
   }, [editor, onEscape]);
 

--- a/packages/scribe/src/adaptors/note-usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/note-usj-editor.adaptor.ts
@@ -88,8 +88,6 @@ import {
 import { MarkerNode, SerializedMarkerNode } from "shared/nodes/scripture/usj/MarkerNode";
 import {
   NBSP,
-  TEXT_SPACING_CLASS_NAME,
-  FORMATTED_FONT_CLASS_NAME,
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
   getUnknownAttributes,
@@ -99,7 +97,7 @@ import { EditorAdaptor } from "shared-react/adaptors/editor-adaptor.model";
 import { CallerData, generateNoteCaller } from "shared-react/nodes/scripture/usj/node-react.utils";
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import { LoggerBasic } from "shared-react/plugins/logger-basic.model";
-import { ViewOptions, getViewOptions } from "./view-options.utils";
+import { ViewOptions, getClassList, getVerseNodeClass, getViewOptions } from "./view-options.utils";
 
 interface UsjNoteEditorAdapter extends EditorAdaptor {
   initialize: typeof initialize;
@@ -214,40 +212,6 @@ function setLogger(logger: LoggerBasic | undefined) {
   if (logger) _logger = logger;
 }
 
-/**
- * Get the chapter node class for the given view options.
- * @param viewOptions - View options of the editor.
- * @returns the chapter node class if the view is defined, `undefined` otherwise.
- */
-export function getChapterNodeClass(viewOptions: ViewOptions | undefined) {
-  if (!viewOptions) return;
-
-  return viewOptions.markerMode === "editable" ? ChapterNode : ImmutableChapterNode;
-}
-
-/**
- * Get the verse node class for the given view options.
- * @param viewOptions - View options of the editor.
- * @returns the verse node class if the view is defined, `undefined` otherwise.
- */
-export function getVerseNodeClass(viewOptions: ViewOptions | undefined) {
-  if (!viewOptions) return;
-
-  return viewOptions.markerMode === "editable" ? VerseNode : ImmutableVerseNode;
-}
-
-/**
- * Get the class list for an element node.
- * @param viewOptions - View options of the editor.
- * @returns the element class list based on view options.
- */
-function getClassList(viewOptions: ViewOptions | undefined) {
-  const classList: string[] = [];
-  if (viewOptions?.hasSpacing) classList.push(TEXT_SPACING_CLASS_NAME);
-  if (viewOptions?.isFormattedFont) classList.push(FORMATTED_FONT_CLASS_NAME);
-  return classList;
-}
-
 function getTextContent(markers: MarkerContent[] | undefined): string {
   if (!markers || markers.length !== 1 || typeof markers[0] !== "string") return "";
 
@@ -284,30 +248,39 @@ function createChapter(
   if (marker !== CHAPTER_MARKER) {
     _logger?.warn(`Unexpected chapter marker '${marker}'!`);
   }
-  const ChapterNodeClass = getChapterNodeClass(_viewOptions) ?? ImmutableChapterNode;
-  const type = ChapterNodeClass.getType();
-  const version =
-    _viewOptions?.markerMode === "editable" ? CHAPTER_VERSION : IMMUTABLE_CHAPTER_VERSION;
-  let text: string | undefined;
   const classList = getClassList(_viewOptions);
-  let showMarker: boolean | undefined;
-  if (_viewOptions?.markerMode === "editable") text = getVisibleOpenMarkerText(marker, number);
-  else if (_viewOptions?.markerMode === "visible") showMarker = true;
   const unknownAttributes = getUnknownAttributes(markerObject);
+  let showMarker: boolean | undefined;
+  if (_viewOptions?.markerMode === "visible") showMarker = true;
 
-  return {
-    type,
-    text,
-    marker: marker as ChapterMarker,
-    number: number ?? "",
-    classList,
-    sid,
-    altnumber,
-    pubnumber,
-    showMarker,
-    unknownAttributes,
-    version,
-  };
+  return _viewOptions?.markerMode === "editable"
+    ? {
+        type: ChapterNode.getType(),
+        marker: marker as ChapterMarker,
+        number: number ?? "",
+        classList,
+        sid,
+        altnumber,
+        pubnumber,
+        unknownAttributes,
+        children: [createText(getVisibleOpenMarkerText(marker, number) ?? "")],
+        direction: null,
+        format: "",
+        indent: 0,
+        version: CHAPTER_VERSION,
+      }
+    : {
+        type: ImmutableChapterNode.getType(),
+        marker: marker as ChapterMarker,
+        number: number ?? "",
+        classList,
+        showMarker,
+        sid,
+        altnumber,
+        pubnumber,
+        unknownAttributes,
+        version: IMMUTABLE_CHAPTER_VERSION,
+      };
 }
 
 function createVerse(

--- a/packages/scribe/src/adaptors/usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/usj-editor.adaptor.ts
@@ -88,8 +88,6 @@ import {
 import { MarkerNode, SerializedMarkerNode } from "shared/nodes/scripture/usj/MarkerNode";
 import {
   NBSP,
-  TEXT_SPACING_CLASS_NAME,
-  FORMATTED_FONT_CLASS_NAME,
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
   getUnknownAttributes,
@@ -99,7 +97,7 @@ import { EditorAdaptor } from "shared-react/adaptors/editor-adaptor.model";
 import { CallerData, generateNoteCaller } from "shared-react/nodes/scripture/usj/node-react.utils";
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import { LoggerBasic } from "shared-react/plugins/logger-basic.model";
-import { ViewOptions, getViewOptions } from "./view-options.utils";
+import { ViewOptions, getClassList, getVerseNodeClass, getViewOptions } from "./view-options.utils";
 
 interface UsjEditorAdaptor extends EditorAdaptor {
   initialize: typeof initialize;
@@ -199,40 +197,6 @@ function setLogger(logger: LoggerBasic | undefined) {
   if (logger) _logger = logger;
 }
 
-/**
- * Get the chapter node class for the given view options.
- * @param viewOptions - View options of the editor.
- * @returns the chapter node class if the view is defined, `undefined` otherwise.
- */
-export function getChapterNodeClass(viewOptions: ViewOptions | undefined) {
-  if (!viewOptions) return;
-
-  return viewOptions.markerMode === "editable" ? ChapterNode : ImmutableChapterNode;
-}
-
-/**
- * Get the verse node class for the given view options.
- * @param viewOptions - View options of the editor.
- * @returns the verse node class if the view is defined, `undefined` otherwise.
- */
-export function getVerseNodeClass(viewOptions: ViewOptions | undefined) {
-  if (!viewOptions) return;
-
-  return viewOptions.markerMode === "editable" ? VerseNode : ImmutableVerseNode;
-}
-
-/**
- * Get the class list for an element node.
- * @param viewOptions - View options of the editor.
- * @returns the element class list based on view options.
- */
-function getClassList(viewOptions: ViewOptions | undefined) {
-  const classList: string[] = [];
-  if (viewOptions?.hasSpacing) classList.push(TEXT_SPACING_CLASS_NAME);
-  if (viewOptions?.isFormattedFont) classList.push(FORMATTED_FONT_CLASS_NAME);
-  return classList;
-}
-
 function getTextContent(markers: MarkerContent[] | undefined): string {
   if (!markers || markers.length !== 1 || typeof markers[0] !== "string") return "";
 
@@ -269,30 +233,39 @@ function createChapter(
   if (marker !== CHAPTER_MARKER) {
     _logger?.warn(`Unexpected chapter marker '${marker}'!`);
   }
-  const ChapterNodeClass = getChapterNodeClass(_viewOptions) ?? ImmutableChapterNode;
-  const type = ChapterNodeClass.getType();
-  const version =
-    _viewOptions?.markerMode === "editable" ? CHAPTER_VERSION : IMMUTABLE_CHAPTER_VERSION;
-  let text: string | undefined;
   const classList = getClassList(_viewOptions);
-  let showMarker: boolean | undefined;
-  if (_viewOptions?.markerMode === "editable") text = getVisibleOpenMarkerText(marker, number);
-  else if (_viewOptions?.markerMode === "visible") showMarker = true;
   const unknownAttributes = getUnknownAttributes(markerObject);
+  let showMarker: boolean | undefined;
+  if (_viewOptions?.markerMode === "visible") showMarker = true;
 
-  return {
-    type,
-    text,
-    marker: marker as ChapterMarker,
-    number: number ?? "",
-    classList,
-    sid,
-    altnumber,
-    pubnumber,
-    showMarker,
-    unknownAttributes,
-    version,
-  };
+  return _viewOptions?.markerMode === "editable"
+    ? {
+        type: ChapterNode.getType(),
+        marker: marker as ChapterMarker,
+        number: number ?? "",
+        classList,
+        sid,
+        altnumber,
+        pubnumber,
+        unknownAttributes,
+        children: [createText(getVisibleOpenMarkerText(marker, number) ?? "")],
+        direction: null,
+        format: "",
+        indent: 0,
+        version: CHAPTER_VERSION,
+      }
+    : {
+        type: ImmutableChapterNode.getType(),
+        marker: marker as ChapterMarker,
+        number: number ?? "",
+        classList,
+        showMarker,
+        sid,
+        altnumber,
+        pubnumber,
+        unknownAttributes,
+        version: IMMUTABLE_CHAPTER_VERSION,
+      };
 }
 
 function createVerse(

--- a/packages/scribe/src/adaptors/view-options.utils.ts
+++ b/packages/scribe/src/adaptors/view-options.utils.ts
@@ -1,3 +1,11 @@
+import { ChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
+import { ImmutableChapterNode } from "shared/nodes/scripture/usj/ImmutableChapterNode";
+import { ImmutableVerseNode } from "shared/nodes/scripture/usj/ImmutableVerseNode";
+import {
+  TEXT_SPACING_CLASS_NAME,
+  FORMATTED_FONT_CLASS_NAME,
+} from "shared/nodes/scripture/usj/node.utils";
+import { VerseNode } from "shared/nodes/scripture/usj/VerseNode";
 import { ViewMode, FORMATTED_VIEW_MODE, UNFORMATTED_VIEW_MODE } from "./view-mode.model";
 
 export type ViewOptions = {
@@ -52,4 +60,38 @@ export function viewOptionsToMode(viewOptions: ViewOptions | undefined): ViewMod
   if (markerMode === "hidden" && hasSpacing && isFormattedFont) return FORMATTED_VIEW_MODE;
   if (markerMode === "editable" && !hasSpacing && !isFormattedFont) return UNFORMATTED_VIEW_MODE;
   return undefined;
+}
+
+/**
+ * Get the chapter node class for the given view options.
+ * @param viewOptions - View options of the editor.
+ * @returns the chapter node class if the view is defined, `undefined` otherwise.
+ */
+export function getChapterNodeClass(viewOptions: ViewOptions | undefined) {
+  if (!viewOptions) return;
+
+  return viewOptions.markerMode === "editable" ? ChapterNode : ImmutableChapterNode;
+}
+
+/**
+ * Get the verse node class for the given view options.
+ * @param viewOptions - View options of the editor.
+ * @returns the verse node class if the view is defined, `undefined` otherwise.
+ */
+export function getVerseNodeClass(viewOptions: ViewOptions | undefined) {
+  if (!viewOptions) return;
+
+  return viewOptions.markerMode === "editable" ? VerseNode : ImmutableVerseNode;
+}
+
+/**
+ * Get the class list for an element node.
+ * @param viewOptions - View options of the editor.
+ * @returns the element class list based on view options.
+ */
+export function getClassList(viewOptions: ViewOptions | undefined) {
+  const classList: string[] = [];
+  if (viewOptions?.hasSpacing) classList.push(TEXT_SPACING_CLASS_NAME);
+  if (viewOptions?.isFormattedFont) classList.push(FORMATTED_FONT_CLASS_NAME);
+  return classList;
 }

--- a/packages/scribe/src/components/insertFunctions.ts
+++ b/packages/scribe/src/components/insertFunctions.ts
@@ -51,11 +51,13 @@ export function insertChapterNode({
     altnumber: string = "xx",
     pubnumber: string = "xx",
     text: string = chapter,
-    classList: string[] = ["chapter", "usfm_c", "text-spacing", "formatted-font"];
+    classList: string[] = ["text-spacing", "formatted-font"];
   editor.update(() => {
     const selection = $getSelection();
     if ($isRangeSelection(selection)) {
-      const chapterNode = $createChapterNode(chapter, classList, text, sid, altnumber, pubnumber);
+      const chapterNode = $createChapterNode(chapter, classList, sid, altnumber, pubnumber);
+      const textNode = $createTextNode(text);
+      chapterNode.append(textNode);
       const spaceNode = $createTextNode(" ");
       selection.insertNodes([chapterNode, spaceNode]);
       moveToEndOfNode(selection, spaceNode);

--- a/packages/scribe/src/plugins/ScriptureReferencePlugin.tsx
+++ b/packages/scribe/src/plugins/ScriptureReferencePlugin.tsx
@@ -18,9 +18,13 @@ import {
   removeNodeAndAfter,
   removeNodesBeforeNode,
 } from "shared/nodes/scripture/usj/node.utils";
-import { ViewOptions } from "../adaptors/view-options.utils";
-import { getChapterNodeClass, getVerseNodeClass } from "../adaptors/usj-editor.adaptor";
 import { BookCode } from "utilities/src/converters/usj/usj.model.ts";
+import {
+  getChapterNodeClass,
+  getVerseNodeClass,
+  getViewOptions,
+  ViewOptions,
+} from "../adaptors/view-options.utils";
 
 /** Prevents the cursor being moved again after a selection has changed. */
 let hasSelectionChanged = false;
@@ -41,7 +45,7 @@ export interface ScriptureReference {
 export function ScriptureReferencePlugin({
   scrRef,
   setScrRef,
-  viewOptions,
+  viewOptions = getViewOptions(),
 }: {
   scrRef: ScriptureReference;
   setScrRef: React.Dispatch<React.SetStateAction<ScriptureReference>>;
@@ -74,13 +78,15 @@ export function ScriptureReferencePlugin({
   }, [editor, chapterNum, verseNum, viewOptions]);
 
   // selection changed
-  useEffect(() => {
-    editor.registerCommand(
-      SELECTION_CHANGE_COMMAND,
-      () => $findAndSetChapterAndVerse(bookCode, chapterNum, verseNum, setScrRef, viewOptions),
-      COMMAND_PRIORITY_LOW,
-    );
-  }, [editor, bookCode, chapterNum, verseNum, setScrRef, viewOptions]);
+  useEffect(
+    () =>
+      editor.registerCommand(
+        SELECTION_CHANGE_COMMAND,
+        () => $findAndSetChapterAndVerse(bookCode, chapterNum, verseNum, setScrRef, viewOptions),
+        COMMAND_PRIORITY_LOW,
+      ),
+    [editor, bookCode, chapterNum, verseNum, setScrRef, viewOptions],
+  );
 
   editor.registerUpdateListener(({ editorState }) => {
     $getBookCode(editorState, setScrRef);

--- a/packages/shared-react/plugins/ClipboardPlugin.tsx
+++ b/packages/shared-react/plugins/ClipboardPlugin.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect } from "react";
+import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { IS_APPLE } from "@lexical/utils";
 import { COPY_COMMAND, CUT_COMMAND } from "lexical";
@@ -7,7 +7,7 @@ import { pasteSelection, pasteSelectionAsPlainText } from "./clipboard.utils";
 export default function ClipboardPlugin(): null {
   const [editor] = useLexicalComposerContext();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const { key, shiftKey, metaKey, ctrlKey, altKey } = event;
       if (!(IS_APPLE ? metaKey : ctrlKey) || altKey) return;

--- a/packages/shared/nodes/scripture/usj/ChapterNode.ts
+++ b/packages/shared/nodes/scripture/usj/ChapterNode.ts
@@ -5,10 +5,8 @@ import {
   type NodeKey,
   $applyNodeReplacement,
   Spread,
-  TextNode,
   SerializedElementNode,
   ElementNode,
-  $createTextNode,
 } from "lexical";
 import { CHAPTER_CLASS_NAME, UnknownAttributes } from "./node.utils";
 
@@ -21,7 +19,6 @@ export type SerializedChapterNode = Spread<
     marker: ChapterMarker;
     number: string;
     classList: string[];
-    text?: string;
     sid?: string;
     altnumber?: string;
     pubnumber?: string;
@@ -42,7 +39,6 @@ export class ChapterNode extends ElementNode {
   constructor(
     chapterNumber: string,
     classList: string[] = [],
-    text?: string,
     sid?: string,
     altnumber?: string,
     pubnumber?: string,
@@ -57,7 +53,6 @@ export class ChapterNode extends ElementNode {
     this.__altnumber = altnumber;
     this.__pubnumber = pubnumber;
     this.__unknownAttributes = unknownAttributes;
-    this.append($createTextNode(text ?? chapterNumber));
   }
 
   static getType(): string {
@@ -67,11 +62,9 @@ export class ChapterNode extends ElementNode {
   static clone(node: ChapterNode): ChapterNode {
     const { __number, __classList, __sid, __altnumber, __pubnumber, __unknownAttributes, __key } =
       node;
-    const __text = node.getFirstChild<TextNode>()?.getTextContent();
     return new ChapterNode(
       __number,
       __classList,
-      __text,
       __sid,
       __altnumber,
       __pubnumber,
@@ -85,7 +78,6 @@ export class ChapterNode extends ElementNode {
       marker,
       number,
       classList,
-      text,
       sid,
       altnumber,
       pubnumber,
@@ -97,7 +89,6 @@ export class ChapterNode extends ElementNode {
     const node = $createChapterNode(
       number,
       classList,
-      text,
       sid,
       altnumber,
       pubnumber,
@@ -188,6 +179,12 @@ export class ChapterNode extends ElementNode {
     return dom;
   }
 
+  updateDOM(): boolean {
+    // Returning false tells Lexical that this node does not need its
+    // DOM element replacing with a new copy from createDOM.
+    return false;
+  }
+
   exportJSON(): SerializedChapterNode {
     return {
       ...super.exportJSON(),
@@ -195,7 +192,6 @@ export class ChapterNode extends ElementNode {
       marker: this.getMarker(),
       number: this.getNumber(),
       classList: this.getClassList(),
-      text: this.getFirstChild<TextNode>()?.getTextContent(),
       sid: this.getSid(),
       altnumber: this.getAltnumber(),
       pubnumber: this.getPubnumber(),
@@ -208,14 +204,13 @@ export class ChapterNode extends ElementNode {
 export function $createChapterNode(
   chapterNumber: string,
   classList?: string[],
-  text?: string,
   sid?: string,
   altnumber?: string,
   pubnumber?: string,
   unknownAttributes?: UnknownAttributes,
 ): ChapterNode {
   return $applyNodeReplacement(
-    new ChapterNode(chapterNumber, classList, text, sid, altnumber, pubnumber, unknownAttributes),
+    new ChapterNode(chapterNumber, classList, sid, altnumber, pubnumber, unknownAttributes),
   );
 }
 

--- a/packages/shared/nodes/scripture/usj/ImmutableChapterNode.ts
+++ b/packages/shared/nodes/scripture/usj/ImmutableChapterNode.ts
@@ -17,6 +17,7 @@ import { CHAPTER_CLASS_NAME, UnknownAttributes, getVisibleOpenMarkerText } from 
 
 export const CHAPTER_MARKER = "c";
 export const IMMUTABLE_CHAPTER_VERSION = 1;
+const IMMUTABLE_CHAPTER_TAG_NAME = "span";
 
 type ChapterMarker = typeof CHAPTER_MARKER;
 
@@ -111,7 +112,7 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
   static importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
-        if (!isChapterElement(node)) return null;
+        if (!isImmutableChapterElement(node)) return null;
 
         return {
           conversion: $convertImmutableChapterElement,
@@ -202,7 +203,7 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
   }
 
   createDOM(): HTMLElement {
-    const dom = document.createElement("span");
+    const dom = document.createElement(IMMUTABLE_CHAPTER_TAG_NAME);
     dom.setAttribute("data-marker", this.__marker);
     dom.classList.add(CHAPTER_CLASS_NAME, `usfm_${this.__marker}`, ...this.__classList);
     dom.setAttribute("data-number", this.__number);
@@ -246,6 +247,12 @@ export class ImmutableChapterNode extends DecoratorNode<void> {
       version: IMMUTABLE_CHAPTER_VERSION,
     };
   }
+
+  // Mutation
+
+  isInline(): false {
+    return false;
+  }
 }
 
 function $convertImmutableChapterElement(element: HTMLElement): DOMConversionOutput {
@@ -280,9 +287,13 @@ export function $createImmutableChapterNode(
   );
 }
 
-function isChapterElement(node: HTMLElement | null | undefined): boolean {
-  const marker = node?.getAttribute("data-marker") ?? undefined;
-  return marker === CHAPTER_MARKER;
+export function isImmutableChapterElement(element: HTMLElement | null | undefined): boolean {
+  if (!element) return false;
+
+  return (
+    element.classList.contains(CHAPTER_CLASS_NAME) &&
+    element.tagName.toLowerCase() === IMMUTABLE_CHAPTER_TAG_NAME
+  );
 }
 
 export function $isImmutableChapterNode(

--- a/packages/shared/nodes/scripture/usj/node-utils.test.ts
+++ b/packages/shared/nodes/scripture/usj/node-utils.test.ts
@@ -1,6 +1,11 @@
 import { MarkerObject } from "@biblionexus-foundation/scripture-utilities";
 import { $createTextNode, $getNodeByKey, $getRoot } from "lexical";
-import { findLastVerse, findThisVerse, getUnknownAttributes } from "./node.utils";
+import {
+  findLastVerse,
+  findThisVerse,
+  getUnknownAttributes,
+  parseNumberFromMarkerText,
+} from "./node.utils";
 import { $createImmutableVerseNode } from "./ImmutableVerseNode";
 import { $createVerseNode, VerseNode } from "./VerseNode";
 import { $createParaNode } from "./ParaNode";
@@ -159,6 +164,28 @@ describe("Editor Node Utilities", () => {
       const unknownAttributes = getUnknownAttributes({ type: "", marker: "" });
 
       expect(unknownAttributes).toBeUndefined();
+    });
+  });
+
+  describe("parseNumberFromMarkerText()", () => {
+    it("should return the default if not found", () => {
+      const marker = "";
+      const text = "";
+      const defaultNumber = "0";
+
+      const number = parseNumberFromMarkerText(marker, text, defaultNumber);
+
+      expect(number).toEqual("0");
+    });
+
+    it("should return the number if found", () => {
+      const marker = "c";
+      const text = "\\c 1 ";
+      const defaultNumber = "0";
+
+      const number = parseNumberFromMarkerText(marker, text, defaultNumber);
+
+      expect(number).toEqual("1");
     });
   });
 });

--- a/packages/shared/nodes/scripture/usj/node.utils.ts
+++ b/packages/shared/nodes/scripture/usj/node.utils.ts
@@ -331,6 +331,26 @@ export function closingMarkerText(marker: string): string {
 }
 
 /**
+ * Parse number from marker text.
+ * @param marker - Chapter or verse marker.
+ * @param text - Text to parse.
+ * @param number - Default number to use if none is found.
+ * @returns the parsed number or the default value as a string.
+ */
+export function parseNumberFromMarkerText(
+  marker: string,
+  text: string | undefined,
+  number: string,
+): string {
+  const openMarkerText = openingMarkerText(marker);
+  if (text && text.startsWith(openMarkerText)) {
+    const numberText = parseInt(text.slice(openMarkerText.length), 10);
+    if (!isNaN(numberText)) number = numberText.toString();
+  }
+  return number;
+}
+
+/**
  * Gets the open marker text with the marker visible.
  * @param marker - Verse marker.
  * @param content - Content such as chapter or verse number.
@@ -373,7 +393,6 @@ export function getEditableCallerText(noteCaller: string): string {
  * @param childNodes - Child nodes of the NoteNode.
  * @returns the preview text.
  */
-
 export function getNoteCallerPreviewText(childNodes: LexicalNode[]): string {
   const previewText = childNodes
     .reduce(

--- a/packages/utilities/src/converters/usj/converter-test.data.ts
+++ b/packages/utilities/src/converters/usj/converter-test.data.ts
@@ -347,9 +347,22 @@ export const editorStateGen1v1Editable = {
         marker: "c",
         number: "1",
         sid: "GEN 1",
-        text: `\\c${NBSP}1 `,
         classList: [],
+        direction: null,
+        format: "",
+        indent: 0,
         version: 1,
+        children: [
+          {
+            type: "text",
+            text: `\\c${NBSP}1 `,
+            detail: 0,
+            format: 0,
+            mode: "normal",
+            style: "",
+            version: 1,
+          },
+        ],
       },
       {
         type: "para",


### PR DESCRIPTION
- Relies on fix in Lexical v0.17.0
- no context menu for `ImmutableChapterNode`
- ensure `ImmutableChapterNode` is not inline for c/v
- also ChapterNode no longer appends a text child (since this previously caused a stack overflow for BookNode)
- also ensure Scribe `ScriptureReferencePlugin` will unregister its command
- also move functions and various clean-ups
- also make unit tests run silently