### PR TITLE
Update Platform name in README.md

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -1,4 +1,4 @@
-# Scripture Editor for Platform.Bible using USX3.0 <-> USJ
+# Scripture Editor for [Platform](https://platform.bible) using USX3.0 ↔ USJ
 
 <div align="center">
 


### PR DESCRIPTION
Platform.Bible was rebranded to be "Platform". It's keeping the website https://platform.bible.