### PR TITLE
135 onchange fired when loading new text

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -101,7 +101,6 @@ export type EditorProps<TLogger extends LoggerBasic> = {
   options?: EditorOptions;
   /** Callback function when USJ Scripture data has changed. */
   onChange?: (usj: Usj) => void;
-  onMutation?: (usj: Usj) => void;
   /** Logger instance. */
   logger?: TLogger;
 };

--- a/packages/platform/src/editor/ScriptureReferencePlugin.tsx
+++ b/packages/platform/src/editor/ScriptureReferencePlugin.tsx
@@ -51,24 +51,30 @@ export default function ScriptureReferencePlugin({
   useEffect(
     () =>
       editor.registerMutationListener(BookNode, (nodeMutations) => {
-        editor.update(() => {
-          for (const [nodeKey, mutation] of nodeMutations) {
-            const bookNode = $getNodeByKey<BookNode>(nodeKey);
-            if (bookNode && $isBookNode(bookNode) && mutation === "created") {
-              $moveCursorToVerseStart(chapterNum, verseNum, viewOptions);
+        editor.update(
+          () => {
+            for (const [nodeKey, mutation] of nodeMutations) {
+              const bookNode = $getNodeByKey<BookNode>(nodeKey);
+              if (bookNode && $isBookNode(bookNode) && mutation === "created") {
+                $moveCursorToVerseStart(chapterNum, verseNum, viewOptions);
+              }
             }
-          }
-        });
+          },
+          { tag: "cursor-change" },
+        );
       }),
     [editor, chapterNum, verseNum, viewOptions],
   );
 
   // Scripture Ref changed
   useEffect(() => {
-    editor.update(() => {
-      if (!hasSelectionChanged) $moveCursorToVerseStart(chapterNum, verseNum, viewOptions);
-      else hasSelectionChanged = false;
-    });
+    editor.update(
+      () => {
+        if (!hasSelectionChanged) $moveCursorToVerseStart(chapterNum, verseNum, viewOptions);
+        else hasSelectionChanged = false;
+      },
+      { tag: "cursor-change" },
+    );
   }, [editor, chapterNum, verseNum, viewOptions]);
 
   // selection changed

--- a/packages/shared-react/annotation/AnnotationPlugin.tsx
+++ b/packages/shared-react/annotation/AnnotationPlugin.tsx
@@ -206,16 +206,19 @@ const AnnotationPlugin = forwardRef(function AnnotationPlugin<TLogger extends Lo
             " Use the appropriate plugin instead.",
         );
 
-      editor.update(() => {
-        // Apply the annotation to the selected range.
-        const rangeSelection = $getRangeFromSelection(selection);
-        if (rangeSelection === undefined) {
-          logger?.error("Failed to find start or end node of the annotation.");
-          return;
-        }
+      editor.update(
+        () => {
+          // Apply the annotation to the selected range.
+          const rangeSelection = $getRangeFromSelection(selection);
+          if (rangeSelection === undefined) {
+            logger?.error("Failed to find start or end node of the annotation.");
+            return;
+          }
 
-        $wrapSelectionInTypedMarkNode(rangeSelection, type, id);
-      });
+          $wrapSelectionInTypedMarkNode(rangeSelection, type, id);
+        },
+        { tag: "annotation-change" },
+      );
     },
 
     removeAnnotation(type, id) {
@@ -229,17 +232,20 @@ const AnnotationPlugin = forwardRef(function AnnotationPlugin<TLogger extends Lo
       if (markNodeKeys !== undefined) {
         // Do async to avoid causing a React infinite loop
         setTimeout(() => {
-          editor.update(() => {
-            for (const key of markNodeKeys) {
-              const node: TypedMarkNode | null = $getNodeByKey(key);
-              if ($isTypedMarkNode(node)) {
-                node.deleteID(type, id);
-                if (node.hasNoIDsForEveryType()) {
-                  $unwrapTypedMarkNode(node);
+          editor.update(
+            () => {
+              for (const key of markNodeKeys) {
+                const node: TypedMarkNode | null = $getNodeByKey(key);
+                if ($isTypedMarkNode(node)) {
+                  node.deleteID(type, id);
+                  if (node.hasNoIDsForEveryType()) {
+                    $unwrapTypedMarkNode(node);
+                  }
                 }
               }
-            }
-          });
+            },
+            { tag: "annotation-change" },
+          );
         });
       }
     },

--- a/packages/shared-react/plugins/UpdateStatePlugin.tsx
+++ b/packages/shared-react/plugins/UpdateStatePlugin.tsx
@@ -35,7 +35,7 @@ export default function UpdateStatePlugin<TLogger extends LoggerBasic>({
     const editorState = editor.parseEditorState(serializedEditorState);
     // Execute after the current render cycle.
     const timeoutId = setTimeout(() => {
-      editor.setEditorState(editorState);
+      editor.setEditorState(editorState, { tag: "external-usj-mutation" });
       editor.dispatchCommand(CLEAR_HISTORY_COMMAND, undefined);
     }, 0);
     return () => clearTimeout(timeoutId);


### PR DESCRIPTION
fixes https://github.com/BiblioNexus-Foundation/scripture-editors/issues/135 by adding tags to editor updates, and ignoring those updates that are not supposed to trigger the onChange callback.