### PR TITLE
fix double-click word after note node

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,8 @@
   ],
   "search.exclude": {
     ".git": true,
-    "node_modules": true
+    "node_modules": true,
+    "packages/platform/lib": true
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "[javascript]": {

--- a/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/editor-usj.adaptor.ts
@@ -49,7 +49,6 @@ import {
   NBSP,
   getEditableCallerText,
   parseNumberFromMarkerText,
-  removeEndingZwsp,
   removeUndefinedProperties,
 } from "shared/nodes/scripture/usj/node.utils";
 import { ImmutableNoteCallerNode } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
@@ -188,7 +187,6 @@ function createNoteMarker(
   content: MarkerContent[] | undefined,
 ): MarkerObject {
   const { type, marker, caller, category, unknownAttributes } = node;
-  removeEndingZwsp(content);
   return removeUndefinedProperties({
     type,
     marker,

--- a/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
@@ -12,6 +12,7 @@ import {
   SerializedLexicalNode,
   SerializedLineBreakNode,
   SerializedTextNode,
+  TextModeType,
   TextNode,
 } from "lexical";
 import {
@@ -85,7 +86,6 @@ import {
 import { MarkerNode, SerializedMarkerNode } from "shared/nodes/scripture/usj/MarkerNode";
 import {
   NBSP,
-  addEndingZwspIfMissing,
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
   getUnknownAttributes,
@@ -421,7 +421,10 @@ function createNote(
     const noteCaller = generateNoteCaller(markerObject.caller, noteCallers, callerData, _logger);
     callerNode = createNoteCaller(noteCaller, childNodes);
     childNodes.forEach((node) => {
-      (node as SerializedTextNode).style = "display: none";
+      if (node.type === CharNode.getType()) {
+        (node as SerializedCharNode).mode = "token";
+        (node as SerializedCharNode).style = "display: none";
+      }
     });
   }
   const unknownAttributes = getUnknownAttributes(markerObject);
@@ -436,7 +439,6 @@ function createNote(
   if (openingMarkerNode) children.push(openingMarkerNode);
   children.push(callerNode, ...childNodes);
   if (closingMarkerNode) children.push(closingMarkerNode);
-  addEndingZwspIfMissing(children, TextNode.getType(), createText);
 
   return removeUndefinedProperties({
     type: NoteNode.getType(),
@@ -527,13 +529,13 @@ function createMarker(marker: string, isOpening = true): SerializedMarkerNode {
   };
 }
 
-function createText(text: string): SerializedTextNode {
+function createText(text: string, mode: TextModeType = "normal"): SerializedTextNode {
   return {
     type: TextNode.getType(),
     text,
     detail: 0,
     format: 0,
-    mode: "normal",
+    mode,
     style: "",
     version: 1,
   };

--- a/packages/scribe/src/adaptors/editor-usj.adaptor.ts
+++ b/packages/scribe/src/adaptors/editor-usj.adaptor.ts
@@ -16,7 +16,6 @@ import {
   NBSP,
   getEditableCallerText,
   parseNumberFromMarkerText,
-  removeEndingZwsp,
   removeUndefinedProperties,
 } from "shared/nodes/scripture/usj/node.utils";
 import { BookNode, SerializedBookNode } from "shared/nodes/scripture/usj/BookNode";
@@ -172,7 +171,6 @@ function createNoteMarker(
   content: MarkerContent[] | undefined,
 ): MarkerObject {
   const { type, marker, caller, category, unknownAttributes } = node;
-  removeEndingZwsp(content);
   return removeUndefinedProperties({
     type,
     marker,

--- a/packages/scribe/src/adaptors/note-usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/note-usj-editor.adaptor.ts
@@ -76,7 +76,6 @@ import {
 import { MarkerNode, SerializedMarkerNode } from "shared/nodes/scripture/usj/MarkerNode";
 import {
   NBSP,
-  addEndingZwspIfMissing,
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
   getUnknownAttributes,
@@ -410,9 +409,14 @@ function createNote(
   } else {
     const noteCaller = generateNoteCaller(markerObject.caller, noteCallers, callerData, _logger);
     callerNode = createNoteCaller(noteCaller, childNodes);
-    // childNodes.forEach((node) => {
-    //   (node as SerializedTextNode).style = "display: none";
-    // });
+    /*
+    childNodes.forEach((node) => {
+      if (node.type === CharNode.getType()) {
+        (node as SerializedCharNode).mode = "token";
+        (node as SerializedCharNode).style = "display: none";
+      }
+    });
+    */
   }
   const unknownAttributes = getUnknownAttributes(markerObject);
 
@@ -426,7 +430,6 @@ function createNote(
   if (openingMarkerNode) children.push(openingMarkerNode);
   children.push(callerNode, ...childNodes);
   if (closingMarkerNode) children.push(closingMarkerNode);
-  addEndingZwspIfMissing(children, TextNode.getType(), createText);
 
   return {
     type: NoteNode.getType(),

--- a/packages/scribe/src/adaptors/usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/usj-editor.adaptor.ts
@@ -76,7 +76,6 @@ import {
 import { MarkerNode, SerializedMarkerNode } from "shared/nodes/scripture/usj/MarkerNode";
 import {
   NBSP,
-  addEndingZwspIfMissing,
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
   getUnknownAttributes,
@@ -396,7 +395,10 @@ function createNote(
     const noteCaller = generateNoteCaller(markerObject.caller, noteCallers, callerData, _logger);
     callerNode = createNoteCaller(noteCaller, childNodes);
     childNodes.forEach((node) => {
-      (node as SerializedTextNode).style = "display: none";
+      if (node.type === CharNode.getType()) {
+        (node as SerializedCharNode).mode = "token";
+        (node as SerializedCharNode).style = "display: none";
+      }
     });
   }
   const unknownAttributes = getUnknownAttributes(markerObject);
@@ -411,7 +413,6 @@ function createNote(
   if (openingMarkerNode) children.push(openingMarkerNode);
   children.push(callerNode, ...childNodes);
   if (closingMarkerNode) children.push(closingMarkerNode);
-  addEndingZwspIfMissing(children, TextNode.getType(), createText);
 
   return {
     type: NoteNode.getType(),

--- a/packages/shared-react/plugins/TextDirectionPlugin.tsx
+++ b/packages/shared-react/plugins/TextDirectionPlugin.tsx
@@ -39,39 +39,33 @@ function useArrowKeys(editor: LexicalEditor) {
     const $handleKeyDown = (event: KeyboardEvent): boolean => {
       if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return false;
 
-      return editor.getEditorState().read(() => {
-        const selection = $getSelection();
-        if (!$isRangeSelection(selection)) return false;
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return false;
 
-        // Find the closest paragraph element
-        const anchorNode = selection.anchor.getNode();
-        const paragraphNode = $findMatchingParent(
-          anchorNode,
-          (node) => getNodeElementTagName(node, editor) === "p",
-        );
-        if (!paragraphNode) return false;
+      // Find the closest paragraph element
+      const anchorNode = selection.anchor.getNode();
+      const paragraphNode = $findMatchingParent(
+        anchorNode,
+        (node) => getNodeElementTagName(node, editor) === "p",
+      );
+      if (!paragraphNode) return false;
 
-        // Get the DOM element corresponding to the paragraph node
-        const paragraphElement = editor.getElementByKey(paragraphNode.getKey());
-        if (!paragraphElement) return false;
+      // Get the DOM element corresponding to the paragraph node
+      const paragraphElement = editor.getElementByKey(paragraphNode.getKey());
+      if (!paragraphElement) return false;
 
-        // Check if directions are different
-        const inputDiv = paragraphElement.parentElement;
-        if (!inputDiv || paragraphElement.dir === inputDiv.dir) return false;
+      // Check if directions are different
+      const inputDiv = paragraphElement.parentElement;
+      if (!inputDiv || paragraphElement.dir === inputDiv.dir) return false;
 
-        editor.update(() => {
-          const updatedSelection = $getSelection();
-          if ($isRangeSelection(updatedSelection)) {
-            // Move in the opposite direction
-            const isBackward =
-              (inputDiv.dir === "rtl" && event.key === "ArrowLeft") ||
-              (inputDiv.dir === "ltr" && event.key === "ArrowRight");
-            updatedSelection.modify("move", isBackward, "character");
-          }
-        });
-        event.preventDefault();
-        return true;
-      });
+      // Move in the opposite direction
+      const isBackward =
+        (inputDiv.dir === "rtl" && event.key === "ArrowLeft") ||
+        (inputDiv.dir === "ltr" && event.key === "ArrowRight");
+      selection.modify("move", isBackward, "character");
+
+      event.preventDefault();
+      return true;
     };
 
     return editor.registerCommand(KEY_DOWN_COMMAND, $handleKeyDown, COMMAND_PRIORITY_HIGH);

--- a/packages/shared/nodes/scripture/usj/node.utils.ts
+++ b/packages/shared/nodes/scripture/usj/node.utils.ts
@@ -1,11 +1,7 @@
 /** Utility functions for editor nodes */
 
-import {
-  MARKER_OBJECT_PROPS,
-  MarkerContent,
-  MarkerObject,
-} from "@biblionexus-foundation/scripture-utilities";
-import { LexicalEditor, LexicalNode, SerializedLexicalNode, SerializedTextNode } from "lexical";
+import { MARKER_OBJECT_PROPS, MarkerObject } from "@biblionexus-foundation/scripture-utilities";
+import { LexicalEditor, LexicalNode, SerializedLexicalNode } from "lexical";
 import { ImmutableChapterNode } from "./ImmutableChapterNode";
 import { ChapterNode } from "./ChapterNode";
 import { CharNode, SerializedCharNode } from "./CharNode";
@@ -274,61 +270,6 @@ export function getNoteCallerPreviewText(childNodes: LexicalNode[]): string {
     )
     .trim();
   return previewText;
-}
-
-/**
- * Adds a Zero-Width Space (ZWSP) character to the end of an array of serialized Lexical nodes if
- * it's not already present.
- *
- * @param children - The array of serialized Lexical nodes to process.
- * @param textNodeType - The type identifier for text nodes in the Lexical structure.
- * @param createTextNodeFn - A function that creates a new serialized text node given a string.
- * @returns This function doesn't return a value; it modifies the input array in place if necessary.
- *
- * @remarks
- * - This function mutates the input array if a ZWSP needs to be added.
- * - The function only adds a ZWSP if the last child is not already a text node with ZWSP content.
- *
- * @example
- * const nodes: SerializedLexicalNode[] = [{ type: 'text', text: 'Hello' }];
- * const createTextNode = (text: string) => ({ type: 'text', text });
- * addEndingZwspIfMissing(nodes, 'text', createTextNode);
- * // nodes is now [{ type: 'text', text: 'Hello' }, { type: 'text', text: ZWSP }]
- */
-export function addEndingZwspIfMissing(
-  children: SerializedLexicalNode[] = [],
-  textNodeType: string,
-  createTextNodeFn: (text: string) => SerializedTextNode,
-) {
-  const lastChild = children.length > 0 ? children[children.length - 1] : undefined;
-  if (
-    lastChild &&
-    lastChild.type === textNodeType &&
-    (lastChild as SerializedTextNode).text === ZWSP
-  )
-    return;
-
-  children.push(createTextNodeFn(ZWSP));
-}
-
-/**
- * Removes the Zero-Width Space (ZWSP) character from the end of a MarkerContent array if present.
- *
- * @param content - The array of MarkerContent to process.
- * @returns This function doesn't return a value; it modifies the input array in place.
- *
- * @remarks
- * - This function mutates the input array.
- * - It only removes the ZWSP if it's the last element and is a string.
- *
- * @example
- * const content: MarkerContent[] = ['Some text', 'More text', ZWSP];
- * removeEndingZwsp(content);
- * // content is now ['Some text', 'More text']
- */
-export function removeEndingZwsp(content: MarkerContent[] = []) {
-  const lastChild = content.length > 0 ? content[content.length - 1] : undefined;
-  if (lastChild && typeof lastChild === "string" && lastChild === ZWSP) content.pop();
 }
 
 /**

--- a/packages/utilities/src/converters/usj/converter-test.data.ts
+++ b/packages/utilities/src/converters/usj/converter-test.data.ts
@@ -2,7 +2,6 @@ import type { SerializedEditorState } from "lexical";
 import { MarkerContent, Usj } from "./usj.model";
 
 const NBSP = "\u00A0";
-const ZWSP = "\u200B";
 
 export const usxEmpty = '<usx version="3.0" />';
 
@@ -271,7 +270,7 @@ export const editorStateGen1v1 = {
                 style: "display: none",
                 detail: 0,
                 format: 0,
-                mode: "normal",
+                mode: "token",
                 version: 1,
               },
               {
@@ -281,16 +280,7 @@ export const editorStateGen1v1 = {
                 style: "display: none",
                 detail: 0,
                 format: 0,
-                mode: "normal",
-                version: 1,
-              },
-              {
-                type: "text",
-                text: ZWSP,
-                detail: 0,
-                format: 0,
-                mode: "normal",
-                style: "",
+                mode: "token",
                 version: 1,
               },
             ],
@@ -667,15 +657,6 @@ export const editorStateGen1v1Editable = {
                 marker: "f",
                 isOpening: false,
                 text: "",
-                detail: 0,
-                format: 0,
-                mode: "normal",
-                style: "",
-                version: 1,
-              },
-              {
-                type: "text",
-                text: ZWSP,
                 detail: 0,
                 format: 0,
                 mode: "normal",
@@ -1424,16 +1405,7 @@ export const editorStateWithUnknownItems = {
                 style: "display: none",
                 detail: 0,
                 format: 0,
-                mode: "normal",
-                version: 1,
-              },
-              {
-                type: "text",
-                text: ZWSP,
-                detail: 0,
-                format: 0,
-                mode: "normal",
-                style: "",
+                mode: "token",
                 version: 1,
               },
             ],


### PR DESCRIPTION
- fixes paranext/paranext-core#1258
- double-clicking a word after a note node (no space between) only selects the word
- When moving forward with arrow keys, if a note node is next, move to the following node.
- also simplify arrow keys in text direction plugin
- also don't search in `lib` folder