### PR TITLE
fix upgrades for `scripture-utilities`

### DIFF
--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -31,7 +31,7 @@
     "react-dom": ">=18.3.1"
   },
   "dependencies": {
-    "@biblionexus-foundation/scripture-utilities": "workspace:^",
+    "@biblionexus-foundation/scripture-utilities": "workspace:~",
     "@lexical/react": "^0.20.0",
     "@lexical/selection": "^0.20.0",
     "@lexical/text": "^0.20.0",

--- a/packages/scribe/package.json
+++ b/packages/scribe/package.json
@@ -29,7 +29,7 @@
     "react-dom": ">=18.3.1"
   },
   "dependencies": {
-    "@biblionexus-foundation/scripture-utilities": "workspace:^",
+    "@biblionexus-foundation/scripture-utilities": "workspace:~",
     "@lexical/mark": "^0.20.0",
     "@lexical/react": "^0.20.0",
     "@lexical/selection": "^0.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
   packages/platform:
     dependencies:
       '@biblionexus-foundation/scripture-utilities':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../utilities
       '@lexical/react':
         specifier: ^0.20.0
@@ -297,7 +297,7 @@ importers:
   packages/scribe:
     dependencies:
       '@biblionexus-foundation/scripture-utilities':
-        specifier: workspace:^
+        specifier: workspace:~
         version: link:../utilities
       '@lexical/mark':
         specifier: ^0.20.0


### PR DESCRIPTION
- for package versions <1.0.0,  `^` won't allow patch upgrades but `~` will.