### PR TITLE
improve `markers-data` generator

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -48,3 +48,4 @@ Thumbs.db
 
 # NX
 .nx/cache
+**/tsconfig*.json

--- a/packages/shared/utils/usfm/usfmMarkers.ts
+++ b/packages/shared/utils/usfm/usfmMarkers.ts
@@ -1,3 +1,5 @@
+/** Generated file using `nx generate markers-data` with 'https://raw.githubusercontent.com/ubsicap/usfm/refs/heads/master/sty/usfm.sty' */
+
 import { CategoryType, MarkerType, Marker } from "./usfmTypes";
 
 export const usfmMarkers: Record<string, Marker> = {

--- a/packages/shared/utils/usfm/usfmTypes.ts
+++ b/packages/shared/utils/usfm/usfmTypes.ts
@@ -1,3 +1,5 @@
+/** Generated file using `nx generate markers-data` with 'https://raw.githubusercontent.com/ubsicap/usfm/refs/heads/master/sty/usfm.sty' */
+
 export enum CategoryType {
   FileIdentification = "FileIdentification",
   Headers = "Headers",
@@ -26,6 +28,7 @@ export enum MarkerType {
   Paragraph = "Paragraph",
   Character = "Character",
   Note = "Note",
+  Unknown = "Unknown",
 }
 
 export interface Marker {

--- a/tools/usfm-markers/README.md
+++ b/tools/usfm-markers/README.md
@@ -2,6 +2,10 @@
 
 This library was generated with [Nx](https://nx.dev).
 
+## Usage
+
+Run `nx generate markers-data` and when prompted give it a USFM style file URL, e.g. `https://raw.githubusercontent.com/ubsicap/usfm/refs/heads/master/sty/usfm.sty`
+
 ## Building
 
 Run `nx build usfm-markers` to build the library.

--- a/tools/usfm-markers/src/generators/markers-data/files/src/usfmMarkers.ts.template
+++ b/tools/usfm-markers/src/generators/markers-data/files/src/usfmMarkers.ts.template
@@ -1,3 +1,5 @@
+/** Generated file using `nx generate markers-data` with '<%- usfmStyleUrl %>' */
+
 import { CategoryType, MarkerType, Marker } from './usfmTypes';
 
 export const usfmMarkers: Record<string, Marker> = {

--- a/tools/usfm-markers/src/generators/markers-data/files/src/usfmTypes.ts.template
+++ b/tools/usfm-markers/src/generators/markers-data/files/src/usfmTypes.ts.template
@@ -1,3 +1,5 @@
+/** Generated file using `nx generate markers-data` with '<%- usfmStyleUrl %>' */
+
 export enum CategoryType {
   FileIdentification = "FileIdentification",
   Headers = "Headers",
@@ -26,6 +28,7 @@ export enum MarkerType {
   Paragraph = "Paragraph",
   Character = "Character",
   Note = "Note",
+  Unknown = "Unknown",
 }
 
 export interface Marker {

--- a/tools/usfm-markers/src/generators/markers-data/generator.ts
+++ b/tools/usfm-markers/src/generators/markers-data/generator.ts
@@ -1,4 +1,4 @@
-import { formatFiles, generateFiles, Tree } from "@nx/devkit";
+import { generateFiles, Tree } from "@nx/devkit";
 import * as path from "path";
 import { MarkersDataGeneratorSchema } from "./schema";
 
@@ -27,18 +27,18 @@ export async function markersDataGenerator(tree: Tree, options: MarkersDataGener
     CategoryType.PeripheralReferences,
   ]);
 
-  // Function to capitalize the first letter of a string
-  function capitalizeFirstLetter(string: string): string {
-    return string.charAt(0).toUpperCase() + string.slice(1);
+  /** Function to capitalize the first letter of a string */
+  function capitalizeFirstLetter(text: string): string {
+    return text.charAt(0).toUpperCase() + text.slice(1);
   }
 
   // Convert the simplified dictionary to a string representation with proper enum handling
   const simplifiedDictionaryString = Object.entries(simplifiedDictionary)
     .map(([key, value]) => {
       return `  "${key}": {
-    category: CategoryType.${capitalizeFirstLetter(value.category)},
-    type: MarkerType.${capitalizeFirstLetter(value.type)},
-    description: "${value.description.replaceAll(`"`, `'`)}",
+    category: CategoryType.${value.category ? capitalizeFirstLetter(value.category) : CategoryType.Uncategorized},
+    type: MarkerType.${value.type ? capitalizeFirstLetter(value.type) : "Unknown"},
+    description: "${value.description ? value.description.replaceAll(`"`, `'`) : ""}",
     hasEndMarker: ${value.hasEndMarker},
     children: ${JSON.stringify(value.children, null, 4)}
   }`;
@@ -50,8 +50,6 @@ export async function markersDataGenerator(tree: Tree, options: MarkersDataGener
     ...options,
     simplifiedDictionaryString: String.raw`${simplifiedDictionaryString}`,
   });
-
-  await formatFiles(tree);
 }
 
 export default markersDataGenerator;

--- a/tools/usfm-markers/src/generators/markers-data/utils/simplifyMarkersDictionary.ts
+++ b/tools/usfm-markers/src/generators/markers-data/utils/simplifyMarkersDictionary.ts
@@ -2,10 +2,10 @@ import { CategoryType } from "./categoriesMap";
 import { MarkersDictionary, StyleType } from "./generateMarkersDictionary";
 
 export interface SimplifiedMarker {
-  category: CategoryType;
-  type: StyleType;
-  description: string;
-  hasEndMarker: boolean;
+  category?: CategoryType;
+  type?: StyleType;
+  description?: string;
+  hasEndMarker?: boolean;
   children?: Partial<Record<CategoryType, string[]>>;
 }
 


### PR DESCRIPTION
- don't format files since it removes comments from `tsconfig.base.json` and PRs check formatting anyway
- add comment to files stating they are generated
- allow for `usfm.sty` properties to not exist. This allows us to parse https://raw.githubusercontent.com/usfm-bible/tcdocs/refs/heads/main/grammar/usfm3_1.sty