### PR TITLE
can't edit b marker

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -41,6 +41,7 @@ import EditablePlugin from "shared-react/plugins/EditablePlugin";
 import { LoggerBasic } from "shared/adaptors/logger-basic.model";
 import NoteNodePlugin from "shared-react/plugins/NoteNodePlugin";
 import OnSelectionChangePlugin from "shared-react/plugins/OnSelectionChangePlugin";
+import ParaNodePlugin from "shared-react/plugins/ParaNodePlugin";
 import TextDirectionPlugin from "shared-react/plugins/TextDirectionPlugin";
 import { TextDirection } from "shared-react/plugins/text-direction.model";
 import UpdateStatePlugin from "shared-react/plugins/UpdateStatePlugin";
@@ -302,6 +303,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
           <CommandMenuPlugin logger={logger} />
           <ContextMenuPlugin />
           <NoteNodePlugin nodeOptions={nodeOptions} logger={logger} />
+          <ParaNodePlugin />
           <TextDirectionPlugin textDirection={textDirection} />
           {children}
         </div>

--- a/packages/platform/src/editor/toolbar/BlockFormatDropDown.tsx
+++ b/packages/platform/src/editor/toolbar/BlockFormatDropDown.tsx
@@ -6,7 +6,6 @@ import DropDown, { DropDownItem } from "./DropDown";
 type BlockMarkerToBlockNames = typeof blockMarkerToBlockNames;
 
 const commonBlockMarkerToBlockNames = {
-  b: "b - Poetry - Stanza Break (Blank Line)",
   m: "m - Paragraph - Margin - No First Line Indent",
   ms: "ms - Heading - Major Section Level 1",
   nb: "nb - Paragraph - No Break with Previous Paragraph",
@@ -38,6 +37,7 @@ const blockMarkerToBlockNames = {
   ms1: "ms1 - Heading - Major Section Level 1",
   ms2: "ms2 - Heading - Major Section Level 2",
   ms3: "ms3 - Heading - Major Section Level 3",
+  b: "b - Poetry - Stanza Break (Blank Line)",
 };
 
 function blockMarkerToClassName(blockMarker: string) {

--- a/packages/shared-react/plugins/ParaNodePlugin.tsx
+++ b/packages/shared-react/plugins/ParaNodePlugin.tsx
@@ -1,0 +1,41 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getNodeByKey, LexicalEditor } from "lexical";
+import { useEffect } from "react";
+import { $isParaNode, ParaNode } from "shared/nodes/scripture/usj/ParaNode";
+
+/**
+ * Update ParaNode to not contain text if it is a 'b' marker (blank line). However, if the 'b'
+ * ParaNode already contained text, it can be modified (backwards compatible with PT9 & USFM v3.0).
+ * @param node - ParaNode thats needs updating.
+ */
+function $paraNodeTransform(node: ParaNode, editor: LexicalEditor): void {
+  if (!$isParaNode(node) || node.getMarker() !== "b" || node.isEmpty()) return;
+
+  const prevEditorState = editor.getEditorState();
+  const wasEmpty = prevEditorState.read(() => {
+    const prevNode = $getNodeByKey(node.getKey());
+    return $isParaNode(prevNode) && (prevNode?.isEmpty() ?? false);
+  });
+  if (!wasEmpty) return;
+
+  node.clear();
+}
+
+function useParaNode(editor: LexicalEditor) {
+  useEffect(() => {
+    if (!editor.hasNodes([ParaNode])) {
+      throw new Error("ParaNodePlugin: ParaNode not registered on editor!");
+    }
+
+    // Update ParaNode to not contain text if it is a b marker.
+    return editor.registerNodeTransform(ParaNode, (node: ParaNode) =>
+      $paraNodeTransform(node, editor),
+    );
+  }, [editor]);
+}
+
+export default function ParaNodePlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  useParaNode(editor);
+  return null;
+}

--- a/packages/shared/utils/usfm/usfmMarkersOverwrites.ts
+++ b/packages/shared/utils/usfm/usfmMarkersOverwrites.ts
@@ -9,7 +9,7 @@ export type MarkerOverwrite = Partial<
 const paragraphChildren = {
   DivisionMarks: { add: ["v", "c"], remove: [] },
   Paragraphs: { add: ["p"], remove: [] },
-  Poetry: { add: ["q", "q1", "q2", "q3", "q4"], remove: [] },
+  Poetry: { add: ["q", "q1", "q2", "q3", "q4", "b"], remove: [] },
   TitlesHeadings: {
     add: [
       "mte",
@@ -42,6 +42,7 @@ const usfmMarkersOverwrites: Record<string, MarkerOverwrite> = {
   q2: { children: paragraphChildren },
   q3: { children: paragraphChildren },
   q4: { children: paragraphChildren },
+  b: { children: paragraphChildren },
   qm: {
     children: {
       Paragraphs: { add: ["p"], remove: [] },


### PR DESCRIPTION
- can only edit 'b' ParaNode if it already contains text.
- include 'b' (blank line) marker in Marker/Node menu
- 'b' marker no longer selectable in block menu