### PR TITLE
fix verse numbering

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -270,11 +270,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
           />
           <HistoryPlugin />
           {scrRef && onScrRefChange && (
-            <ScriptureReferencePlugin
-              scrRef={scrRef}
-              onScrRefChange={onScrRefChange}
-              viewOptions={viewOptions}
-            />
+            <ScriptureReferencePlugin scrRef={scrRef} onScrRefChange={onScrRefChange} />
           )}
           {scrRef && (
             <UsjNodesMenuPlugin

--- a/packages/platform/src/editor/adaptors/view-options.utils.ts
+++ b/packages/platform/src/editor/adaptors/view-options.utils.ts
@@ -1,5 +1,3 @@
-import { ChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
-import { ImmutableChapterNode } from "shared/nodes/scripture/usj/ImmutableChapterNode";
 import {
   TEXT_SPACING_CLASS_NAME,
   FORMATTED_FONT_CLASS_NAME,
@@ -60,17 +58,6 @@ export function viewOptionsToMode(viewOptions: ViewOptions | undefined): ViewMod
   if (markerMode === "hidden" && hasSpacing && isFormattedFont) return FORMATTED_VIEW_MODE;
   if (markerMode === "editable" && !hasSpacing && !isFormattedFont) return UNFORMATTED_VIEW_MODE;
   return undefined;
-}
-
-/**
- * Get the chapter node class for the given view options.
- * @param viewOptions - View options of the editor.
- * @returns the chapter node class if the view is defined, `undefined` otherwise.
- */
-export function getChapterNodeClass(viewOptions: ViewOptions | undefined) {
-  if (!viewOptions) return;
-
-  return viewOptions.markerMode === "editable" ? ChapterNode : ImmutableChapterNode;
 }
 
 /**

--- a/packages/scribe/src/adaptors/view-options.utils.ts
+++ b/packages/scribe/src/adaptors/view-options.utils.ts
@@ -1,5 +1,3 @@
-import { ChapterNode } from "shared/nodes/scripture/usj/ChapterNode";
-import { ImmutableChapterNode } from "shared/nodes/scripture/usj/ImmutableChapterNode";
 import {
   TEXT_SPACING_CLASS_NAME,
   FORMATTED_FONT_CLASS_NAME,
@@ -60,17 +58,6 @@ export function viewOptionsToMode(viewOptions: ViewOptions | undefined): ViewMod
   if (markerMode === "hidden" && hasSpacing && isFormattedFont) return FORMATTED_VIEW_MODE;
   if (markerMode === "editable" && !hasSpacing && !isFormattedFont) return UNFORMATTED_VIEW_MODE;
   return undefined;
-}
-
-/**
- * Get the chapter node class for the given view options.
- * @param viewOptions - View options of the editor.
- * @returns the chapter node class if the view is defined, `undefined` otherwise.
- */
-export function getChapterNodeClass(viewOptions: ViewOptions | undefined) {
-  if (!viewOptions) return;
-
-  return viewOptions.markerMode === "editable" ? ChapterNode : ImmutableChapterNode;
 }
 
 /**

--- a/packages/scribe/src/components/Editor.tsx
+++ b/packages/scribe/src/components/Editor.tsx
@@ -117,40 +117,38 @@ const Editor = forwardRef(function Editor(
   );
 
   return (
-    <>
-      <LexicalComposer initialConfig={initialConfig}>
-        <RichTextPlugin
-          contentEditable={
-            <ContentEditable
-              className={`editor-input outline-none ${getViewClassList(viewOptions).join(" ")}`}
-            />
-          }
-          placeholder={<LoadingSpinner />}
-          ErrorBoundary={LexicalErrorBoundary}
-        />
-        {/* <UsjNodesMenuPlugin
+    <LexicalComposer initialConfig={initialConfig}>
+      <RichTextPlugin
+        contentEditable={
+          <ContentEditable
+            className={`editor-input outline-none ${getViewClassList(viewOptions).join(" ")}`}
+          />
+        }
+        placeholder={<LoadingSpinner />}
+        ErrorBoundary={LexicalErrorBoundary}
+      />
+      {/* <UsjNodesMenuPlugin
           trigger={NODE_MENU_TRIGGER}
           scrRef={scrRef}
           getMarkerAction={(marker, markerData) =>
             getUsjMarkerAction(marker, markerData, viewOptions)
           }
         /> */}
-        <UpdateStatePlugin
-          scripture={loadedUsj}
-          nodeOptions={nodeOptions}
-          editorAdaptor={usjEditorAdaptor}
-          viewOptions={viewOptions}
-          // logger={logger}
-        />
-        <OnChangePlugin onChange={handleChange} ignoreSelectionChange={true} />
-        <NoteNodePlugin nodeOptions={nodeOptions} />
-        <HistoryPlugin />
-        <AutoFocusPlugin />
-        <ContextMenuPlugin />
-        <ClipboardPlugin />
-        <ScriptureReferencePlugin viewOptions={viewOptions} scrRef={scrRef} setScrRef={setScrRef} />
-      </LexicalComposer>
-    </>
+      <UpdateStatePlugin
+        scripture={loadedUsj}
+        nodeOptions={nodeOptions}
+        editorAdaptor={usjEditorAdaptor}
+        viewOptions={viewOptions}
+        // logger={logger}
+      />
+      <OnChangePlugin onChange={handleChange} ignoreSelectionChange={true} />
+      <NoteNodePlugin nodeOptions={nodeOptions} />
+      <HistoryPlugin />
+      <AutoFocusPlugin />
+      <ContextMenuPlugin />
+      <ClipboardPlugin />
+      <ScriptureReferencePlugin scrRef={scrRef} setScrRef={setScrRef} />
+    </LexicalComposer>
   );
 });
 

--- a/packages/shared-react/nodes/scripture/usj/node-react-utils.test.ts
+++ b/packages/shared-react/nodes/scripture/usj/node-react-utils.test.ts
@@ -5,51 +5,57 @@ import {
   ImmutableChapterNode,
 } from "shared/nodes/scripture/usj/ImmutableChapterNode";
 import { $createParaNode, ParaNode } from "shared/nodes/scripture/usj/ParaNode";
-import { $createVerseNode, VerseNode } from "shared/nodes/scripture/usj/VerseNode";
+import { $createVerseNode } from "shared/nodes/scripture/usj/VerseNode";
 import { createBasicTestEnvironment } from "shared/nodes/test.utils";
-import { findLastVerse, findThisVerse } from "./node-react.utils";
+import { $findLastVerse, $findThisVerse } from "./node-react.utils";
 import { $createImmutableVerseNode, ImmutableVerseNode } from "./ImmutableVerseNode";
 
 describe("Editor Node Utilities", () => {
   describe("findLastVerse()", () => {
-    it("should find the last verse in node", async () => {
+    it("should find the last verse in node", () => {
       const { editor } = createBasicTestEnvironment();
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const v1 = $createVerseNode("1");
-        const v2 = $createVerseNode("2");
-        const t1 = $createTextNode("text1");
-        const t2 = $createTextNode("text2");
-        root.append(p1);
-        p1.append(v1, t1, v2, t2);
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const v1 = $createVerseNode("1");
+          const v2 = $createVerseNode("2");
+          const t1 = $createTextNode("text1");
+          const t2 = $createTextNode("text2");
+          root.append(p1);
+          p1.append(v1, t1, v2, t2);
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const root = $getRoot();
-        const verseNode = findLastVerse<VerseNode>(root.getChildren(), VerseNode);
+        const verseNode = $findLastVerse(root.getChildren());
 
         expect(verseNode).toBeDefined();
         expect(verseNode?.getNumber()).toEqual("2");
       });
     });
 
-    it("should find the last immutable verse in node", async () => {
+    it("should find the last immutable verse in node", () => {
       const { editor } = createBasicTestEnvironment([ParaNode, ImmutableVerseNode]);
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const v2 = $createImmutableVerseNode("2");
-        const t1 = $createTextNode("text1");
-        const t2 = $createTextNode("text2");
-        root.append(p1);
-        p1.append(v1, t1, v2, t2);
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const v2 = $createImmutableVerseNode("2");
+          const t1 = $createTextNode("text1");
+          const t2 = $createTextNode("text2");
+          root.append(p1);
+          p1.append(v1, t1, v2, t2);
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const root = $getRoot();
-        const verseNode = findLastVerse(root.getChildren());
+        const verseNode = $findLastVerse(root.getChildren());
 
         expect(verseNode).toBeDefined();
         expect(verseNode?.getNumber()).toEqual("2");
@@ -58,7 +64,7 @@ describe("Editor Node Utilities", () => {
   });
 
   describe("findThisVerse()", () => {
-    it("should find the last verse in node", async () => {
+    it("should find the last verse in node", () => {
       let t2Key: string;
       const { editor } = createBasicTestEnvironment([ParaNode, ImmutableVerseNode]);
       /*
@@ -67,60 +73,67 @@ describe("Editor Node Utilities", () => {
        * v1 t1 v2 t2
        *          ^^
        */
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const v2 = $createImmutableVerseNode("2");
-        const t1 = $createTextNode("text1");
-        const t2 = $createTextNode("text2");
-        root.append(p1);
-        p1.append(v1, t1, v2, t2);
-        t2Key = t2.getKey();
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const v2 = $createImmutableVerseNode("2");
+          const t1 = $createTextNode("text1");
+          const t2 = $createTextNode("text2");
+          root.append(p1);
+          p1.append(v1, t1, v2, t2);
+          t2Key = t2.getKey();
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const t2 = $getNodeByKey(t2Key);
-        const verseNode = findThisVerse(t2);
+        const verseNode = $findThisVerse(t2);
 
         expect(verseNode).toBeDefined();
         expect(verseNode?.getNumber()).toEqual("2");
       });
     });
 
-    it("should find the last verse in node when the text is in a mark", async () => {
+    it("should find the last verse in node when the text is in a mark", () => {
       let t2Key: string;
       const { editor } = createBasicTestEnvironment([ParaNode, ImmutableVerseNode, TypedMarkNode]);
       /*
        *    root
        *     p1
-       * v1 t1 v2 m1(t2)
-       *             ^^
+       * v1 t1 v2 m1
+       *          t2
+       *          ^^
        */
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const v2 = $createImmutableVerseNode("2");
-        const t1 = $createTextNode("text1");
-        const m1 = $createTypedMarkNode({ ["testType1"]: ["testID1"] });
-        const t2 = $createTextNode("text2");
-        root.append(p1);
-        p1.append(v1, t1, v2, m1);
-        m1.append(t2);
-        t2Key = t2.getKey();
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const v2 = $createImmutableVerseNode("2");
+          const t1 = $createTextNode("text1");
+          const m1 = $createTypedMarkNode({ ["testType1"]: ["testID1"] });
+          const t2 = $createTextNode("text2");
+          root.append(p1);
+          p1.append(v1, t1, v2, m1);
+          m1.append(t2);
+          t2Key = t2.getKey();
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const t2 = $getNodeByKey(t2Key);
-        const verseNode = findThisVerse(t2);
+        const verseNode = $findThisVerse(t2);
 
         expect(verseNode).toBeDefined();
         expect(verseNode?.getNumber()).toEqual("2");
       });
     });
 
-    it("should find the verse in a previous parent node", async () => {
+    it("should find the verse in a previous parent node", () => {
       let t3Key: string;
       const { editor } = createBasicTestEnvironment([ParaNode, ImmutableVerseNode]);
       /*
@@ -129,32 +142,35 @@ describe("Editor Node Utilities", () => {
        * v1 t1    t2    t3
        *                ^^
        */
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const p2 = $createParaNode();
-        const p3 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const t1 = $createTextNode("text1");
-        const t2 = $createTextNode("text2");
-        const t3 = $createTextNode("text3");
-        root.append(p1, p2, p3);
-        p1.append(v1, t1);
-        p2.append(t2);
-        p3.append(t3);
-        t3Key = t3.getKey();
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const p2 = $createParaNode();
+          const p3 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const t1 = $createTextNode("text1");
+          const t2 = $createTextNode("text2");
+          const t3 = $createTextNode("text3");
+          root.append(p1, p2, p3);
+          p1.append(v1, t1);
+          p2.append(t2);
+          p3.append(t3);
+          t3Key = t3.getKey();
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const t3 = $getNodeByKey(t3Key);
-        const verseNode = findThisVerse(t3);
+        const verseNode = $findThisVerse(t3);
 
         expect(verseNode).toBeDefined();
         expect(verseNode?.getNumber()).toEqual("1");
       });
     });
 
-    it("should find the last verse in the previous parent node", async () => {
+    it("should find the last verse in the previous parent node", () => {
       let t2Key: string;
       const { editor } = createBasicTestEnvironment([ParaNode, ImmutableVerseNode]);
       /*
@@ -163,30 +179,73 @@ describe("Editor Node Utilities", () => {
        * v1 t1 v2    t2
        *             ^^
        */
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const p2 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const v2 = $createImmutableVerseNode("2");
-        const t1 = $createTextNode("text1");
-        const t2 = $createTextNode("text2");
-        root.append(p1, p2);
-        p1.append(v1, t1, v2);
-        p2.append(t2);
-        t2Key = t2.getKey();
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const p2 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const v2 = $createImmutableVerseNode("2");
+          const t1 = $createTextNode("text1");
+          const t2 = $createTextNode("text2");
+          root.append(p1, p2);
+          p1.append(v1, t1, v2);
+          p2.append(t2);
+          t2Key = t2.getKey();
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const t2 = $getNodeByKey(t2Key);
-        const verseNode = findThisVerse(t2);
+        const verseNode = $findThisVerse(t2);
 
         expect(verseNode).toBeDefined();
         expect(verseNode?.getNumber()).toEqual("2");
       });
     });
 
-    it("should not find a verse if a chapter is encountered first from para", async () => {
+    it("should find the last verse in a previous parent node if the para is empty", () => {
+      let p3Key: string;
+      const { editor } = createBasicTestEnvironment([
+        ImmutableChapterNode,
+        ParaNode,
+        ImmutableVerseNode,
+      ]);
+      /*
+       *         root
+       * c1    p1     p2    p3
+       *     v1 t1    t2
+       *                    ^^
+       */
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const c1 = $createImmutableChapterNode("1");
+          const p1 = $createParaNode();
+          const p2 = $createParaNode();
+          const p3 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const t1 = $createTextNode("text1");
+          const t2 = $createTextNode("text2");
+          root.append(c1, p1, p2, p3);
+          p1.append(v1, t1);
+          p2.append(t2);
+          p3Key = p3.getKey();
+        },
+        { discrete: true },
+      );
+
+      editor.getEditorState().read(() => {
+        const p3 = $getNodeByKey(p3Key);
+        const verseNode = $findThisVerse(p3);
+
+        expect(verseNode).toBeDefined();
+        expect(verseNode?.getNumber()).toEqual("1");
+      });
+    });
+
+    it("should not find a verse if a chapter is encountered first from para", () => {
       let p2Key: string;
       const { editor } = createBasicTestEnvironment([
         ImmutableChapterNode,
@@ -198,26 +257,29 @@ describe("Editor Node Utilities", () => {
        * p1 c1 p2
        * v1    ^^
        */
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const c1 = $createImmutableChapterNode("1");
-        const p2 = $createParaNode();
-        root.append(p1, c1, p2);
-        p1.append(v1);
-        p2Key = p2.getKey();
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const c1 = $createImmutableChapterNode("1");
+          const p2 = $createParaNode();
+          root.append(p1, c1, p2);
+          p1.append(v1);
+          p2Key = p2.getKey();
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const p2 = $getNodeByKey(p2Key);
-        const verseNode = findThisVerse(p2);
+        const verseNode = $findThisVerse(p2);
 
         expect(verseNode).toBeUndefined();
       });
     });
 
-    it("should not find a verse if a chapter is encountered first from text", async () => {
+    it("should not find a verse if a chapter is encountered first from text", () => {
       let t1Key: string;
       const { editor } = createBasicTestEnvironment([
         ImmutableChapterNode,
@@ -230,22 +292,25 @@ describe("Editor Node Utilities", () => {
        * v1    t1
        *       ^^
        */
-      await editor.update(() => {
-        const root = $getRoot();
-        const p1 = $createParaNode();
-        const v1 = $createImmutableVerseNode("1");
-        const c1 = $createImmutableChapterNode("1");
-        const p2 = $createParaNode();
-        const t1 = $createTextNode("text1");
-        root.append(p1, c1, p2);
-        p1.append(v1);
-        p2.append(t1);
-        t1Key = t1.getKey();
-      });
+      editor.update(
+        () => {
+          const root = $getRoot();
+          const p1 = $createParaNode();
+          const v1 = $createImmutableVerseNode("1");
+          const c1 = $createImmutableChapterNode("1");
+          const p2 = $createParaNode();
+          const t1 = $createTextNode("text1");
+          root.append(p1, c1, p2);
+          p1.append(v1);
+          p2.append(t1);
+          t1Key = t1.getKey();
+        },
+        { discrete: true },
+      );
 
-      await editor.getEditorState().read(() => {
+      editor.getEditorState().read(() => {
         const t1 = $getNodeByKey(t1Key);
-        const verseNode = findThisVerse(t1);
+        const verseNode = $findThisVerse(t1);
 
         expect(verseNode).toBeUndefined();
       });

--- a/packages/shared-react/plugins/UsjNodesMenuPlugin.tsx
+++ b/packages/shared-react/plugins/UsjNodesMenuPlugin.tsx
@@ -2,6 +2,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { $dfs, DFSNode, mergeRegister } from "@lexical/utils";
 import {
   $getNodeByKey,
+  $getRoot,
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_LOW,
@@ -9,7 +10,12 @@ import {
   SELECTION_CHANGE_COMMAND,
 } from "lexical";
 import { useEffect, useMemo, useState } from "react";
-import { getNextVerse } from "shared/nodes/scripture/usj/node.utils";
+import {
+  $findNextChapter,
+  $findThisChapter,
+  getNextVerse,
+  removeNodesBeforeNode,
+} from "shared/nodes/scripture/usj/node.utils";
 import { $isVerseNode, VerseNode } from "shared/nodes/scripture/usj/VerseNode";
 import { GetMarkerAction, ScriptureReference } from "shared/utils/get-marker-action.model";
 import {
@@ -106,7 +112,11 @@ function getVerseRangeSegment(verse: string) {
  * @param insertedNode - Inserted verse node.
  */
 function $renumberAllVerses(insertedNode: VerseNode | ImmutableVerseNode) {
-  const allVerseNodes = $dfs().filter<DfsVerseNode>(
+  const children = $getRoot().getChildren();
+  const chapterNode = $findThisChapter(insertedNode);
+  const nodesInChapter = removeNodesBeforeNode(children, chapterNode);
+  const nextChapterNode = $findNextChapter(nodesInChapter, !!chapterNode);
+  const allVerseNodes = $dfs(chapterNode, nextChapterNode).filter<DfsVerseNode>(
     (dfsNode): dfsNode is DfsVerseNode =>
       $isImmutableVerseNode(dfsNode.node) || $isVerseNode(dfsNode.node),
   );


### PR DESCRIPTION
- renumber only in the current chapter
- refactor node utils to not need the node class or type
- fix numbering when inserting a verse on a new line
- remove redundant `await`s from tests