### PR TITLE
upgrade to pnpm v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "nx": "19.8.14",
     "nx-cloud": "^19.1.0",
     "prettier": "^3.4.2",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "tslib": "^2.8.1",
@@ -56,6 +57,6 @@
   },
   "volta": {
     "node": "20.18.0",
-    "pnpm": "9.15.0"
+    "pnpm": "10.2.1"
   }
 }

--- a/packages/scribe/package.json
+++ b/packages/scribe/package.json
@@ -41,7 +41,6 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "postcss": "^8.5.1",
-    "prettier-plugin-tailwindcss": "^0.6.11",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "shared": "link:../shared",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.11
+        version: 0.6.11(prettier@3.4.2)
       ts-jest:
         specifier: ^29.2.5
         version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.10.14(@swc/helpers@0.5.15))(@types/node@20.17.17)(typescript@5.5.4)))(typescript@5.5.4)
@@ -327,9 +330,6 @@ importers:
       postcss:
         specifier: ^8.5.1
         version: 8.5.1
-      prettier-plugin-tailwindcss:
-        specifier: ^0.6.11
-        version: 0.6.11(prettier@3.4.2)
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
- pnpm 10 changes how dependencies are linked across workspaces. Since this is a monorepo, make sure the prettier plugin is installed at the root.