### PR TITLE
platform: fix verse renumbering

### DIFF
--- a/packages/platform/README.md
+++ b/packages/platform/README.md
@@ -298,7 +298,7 @@ To develop an editor in a target application you can use [yalc](https://www.npmj
    ```bash
    yalc link @biblionexus-foundation/platform-editor
    ```
-3. In this monorepo, make changes and re-publish the editor (see step 2).
+3. In this monorepo, make changes and re-publish the editor (see step 1).
 4. When you have finished developing in the target application repo, unlink from `yalc`:
    ```bash
    yalc remove @biblionexus-foundation/platform-editor && npm i

--- a/packages/platform/src/App.tsx
+++ b/packages/platform/src/App.tsx
@@ -171,7 +171,7 @@ export default function App() {
     const timeoutId = setTimeout(() => {
       marginalRef.current?.setComments?.(comments as Comments);
       marginalRef.current?.setUsj(usxStringToUsj(usx));
-    }, 1000);
+    }, 0);
     return () => clearTimeout(timeoutId);
   }, []);
 

--- a/packages/shared-react/nodes/scripture/usj/node-react.utils.ts
+++ b/packages/shared-react/nodes/scripture/usj/node-react.utils.ts
@@ -11,14 +11,14 @@ import { $isVerseNode, VerseNode } from "shared/nodes/scripture/usj/VerseNode";
 import { $isImmutableNoteCallerNode, ImmutableNoteCallerNode } from "./ImmutableNoteCallerNode";
 import { $isImmutableVerseNode, ImmutableVerseNode } from "./ImmutableVerseNode";
 
-/** Caller count is in an object so it can be manipulated by passing the the object. */
+/** Caller count is in an object so it can be manipulated by passing the object. */
 export type CallerData = {
   count: number;
 };
 
 // If you want use these utils with your own verse node, add it to this list of types, then modify
-// all the functions where this type is used.
-type SomeVerseNode = VerseNode | ImmutableVerseNode;
+// all the functions where this type is used in this file.
+export type SomeVerseNode = VerseNode | ImmutableVerseNode;
 
 /**
  * Generate the note caller to use. E.g. for '+' replace with a-z, aa-zz.

--- a/packages/shared-react/plugins/UsjNodesMenuPlugin.test.tsx
+++ b/packages/shared-react/plugins/UsjNodesMenuPlugin.test.tsx
@@ -1,0 +1,263 @@
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import {
+  $getRoot,
+  $createTextNode,
+  LexicalEditor,
+  $getSelection,
+  $setSelection,
+  $createRangeSelection,
+  $createPoint,
+  TextNode,
+} from "lexical";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import scriptureUsjNodes from "shared/nodes/scripture/usj";
+import { $createImmutableChapterNode } from "shared/nodes/scripture/usj/ImmutableChapterNode";
+import { $createParaNode } from "shared/nodes/scripture/usj/ParaNode";
+import { ScriptureReference } from "shared/utils/get-marker-action.model";
+import { ImmutableNoteCallerNode } from "../nodes/scripture/usj/ImmutableNoteCallerNode";
+import {
+  $createImmutableVerseNode,
+  ImmutableVerseNode,
+} from "../nodes/scripture/usj/ImmutableVerseNode";
+import UsjNodesMenuPlugin from "./UsjNodesMenuPlugin";
+
+let reactRoot: Root;
+let firstVerseNode: ImmutableVerseNode;
+let firstVerseTextNode: TextNode;
+let secondVerseNode: ImmutableVerseNode;
+let secondVerseTextNode: TextNode;
+let thirdVerseNode: ImmutableVerseNode;
+let thirdVerseTextNode: TextNode;
+
+describe("UsjNodesMenuPlugin", () => {
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    reactRoot = createRoot(container);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    // Is defined in beforeEach.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    document.body.removeChild(container!);
+    container = null;
+
+    jest.restoreAllMocks();
+  });
+
+  it("should load default initialEditorState (sanity check)", async () => {
+    const { editor } = await testEnvironment();
+
+    editor.getEditorState().read(() => {
+      expect($getRoot().getTextContent()).toBe(
+        "first verse text \n\nsecond verse text \n\nthird verse text ",
+      );
+      expect(firstVerseNode.getNumber()).toBe("1-2");
+      expect(secondVerseNode.getNumber()).toBe("3a");
+      expect(thirdVerseNode.getNumber()).toBe("4-5a");
+    });
+  });
+
+  describe("Verse Renumbering", () => {
+    it("should insert verse 3 before 3a and renumber to 4a (with verse ranges and segments)", async () => {
+      const { editor } = await testEnvironment();
+
+      await insertVerseNodeAtSelection(editor, "3", firstVerseTextNode);
+
+      editor.getEditorState().read(() => {
+        expect(firstVerseNode.getNumber()).toBe("1-2");
+        expect(secondVerseNode.getNumber()).toBe("4a");
+        expect(thirdVerseNode.getNumber()).toBe("5-6a");
+      });
+    });
+
+    it("should insert verse 3b before 4-5 and not renumber (with verse ranges and segments)", async () => {
+      const { editor } = await testEnvironment();
+
+      await insertVerseNodeAtSelection(editor, "3b", secondVerseTextNode);
+
+      editor.getEditorState().read(() => {
+        expect(firstVerseNode.getNumber()).toBe("1-2");
+        expect(secondVerseNode.getNumber()).toBe("3a");
+        expect(thirdVerseNode.getNumber()).toBe("4-5a");
+      });
+    });
+
+    it("should insert verse 2 before 2 and renumber to 3 (with normal verse numbers)", async () => {
+      function $initialEditorState() {
+        $defaultInitialEditorState();
+        firstVerseNode.setNumber("1");
+        secondVerseNode.setNumber("2");
+        thirdVerseNode.setNumber("3");
+      }
+      const { editor } = await testEnvironment($initialEditorState);
+      editor.getEditorState().read(() => {
+        expect(firstVerseNode.getNumber()).toBe("1");
+        expect(secondVerseNode.getNumber()).toBe("2");
+        expect(thirdVerseNode.getNumber()).toBe("3");
+      });
+
+      await insertVerseNodeAtSelection(editor, "2", firstVerseTextNode);
+
+      editor.getEditorState().read(() => {
+        expect(firstVerseNode.getNumber()).toBe("1");
+        expect(secondVerseNode.getNumber()).toBe("3");
+        expect(thirdVerseNode.getNumber()).toBe("4");
+      });
+    });
+
+    it("should insert verse 2 before 2 and renumber to 3 but only in chapter 1 (with normal verse numbers)", async () => {
+      let ch2FirstVerseNode: ImmutableVerseNode;
+      let ch2SecondVerseNode: ImmutableVerseNode;
+      function $initialEditorState() {
+        $defaultInitialEditorState();
+        firstVerseNode.setNumber("1");
+        secondVerseNode.setNumber("2");
+        thirdVerseNode.setNumber("3");
+        ch2FirstVerseNode = $createImmutableVerseNode("1");
+        ch2SecondVerseNode = $createImmutableVerseNode("2");
+        $getRoot().append(
+          $createImmutableChapterNode("2"),
+          $createParaNode().append(ch2FirstVerseNode, $createTextNode("first verse text ")),
+          $createParaNode().append(ch2SecondVerseNode, $createTextNode("second verse text ")),
+        );
+      }
+      const { editor } = await testEnvironment($initialEditorState);
+      editor.getEditorState().read(() => {
+        expect(firstVerseNode.getNumber()).toBe("1");
+        expect(secondVerseNode.getNumber()).toBe("2");
+        expect(thirdVerseNode.getNumber()).toBe("3");
+        expect(ch2FirstVerseNode.getNumber()).toBe("1");
+        expect(ch2SecondVerseNode.getNumber()).toBe("2");
+      });
+
+      await insertVerseNodeAtSelection(editor, "2", firstVerseTextNode);
+
+      editor.getEditorState().read(() => {
+        expect(firstVerseNode.getNumber()).toBe("1");
+        expect(secondVerseNode.getNumber()).toBe("3");
+        expect(thirdVerseNode.getNumber()).toBe("4");
+        expect(ch2FirstVerseNode.getNumber()).toBe("1");
+        expect(ch2SecondVerseNode.getNumber()).toBe("2");
+      });
+    });
+  });
+});
+
+function $defaultInitialEditorState() {
+  firstVerseNode = $createImmutableVerseNode("1-2");
+  firstVerseTextNode = $createTextNode("first verse text ");
+  secondVerseNode = $createImmutableVerseNode("3a");
+  secondVerseTextNode = $createTextNode("second verse text ");
+  thirdVerseNode = $createImmutableVerseNode("4-5a");
+  thirdVerseTextNode = $createTextNode("third verse text ");
+  $getRoot().append(
+    $createImmutableChapterNode("1"),
+    $createParaNode().append(firstVerseNode, firstVerseTextNode),
+    $createParaNode().append(secondVerseNode, secondVerseTextNode),
+    $createParaNode().append(thirdVerseNode, thirdVerseTextNode),
+  );
+}
+
+async function testEnvironment($initialEditorState: () => void = $defaultInitialEditorState) {
+  const scriptureReference = { book: "GEN", chapterNum: 1, verseNum: 1 };
+  // Can be changed by a test as it is returned by this function.
+  // eslint-disable-next-line prefer-const
+  let verseToInsert = "3";
+
+  let editor: LexicalEditor;
+
+  function GrabEditor() {
+    [editor] = useLexicalComposerContext();
+    return null;
+  }
+
+  function getMarkerAction(marker: string) {
+    return {
+      action: (currentEditor: { reference: ScriptureReference; editor: LexicalEditor }) => {
+        if (marker !== "v") return;
+
+        currentEditor.editor.update(() => {
+          const selection = $getSelection();
+          selection?.insertNodes([$createImmutableVerseNode(verseToInsert)]);
+        });
+      },
+      label: undefined,
+    };
+  }
+
+  function App() {
+    return (
+      <LexicalComposer
+        initialConfig={{
+          editorState: $initialEditorState,
+          namespace: "TestEditor",
+          nodes: [ImmutableNoteCallerNode, ImmutableVerseNode, ...scriptureUsjNodes],
+          onError: () => {
+            throw Error();
+          },
+          theme: {},
+        }}
+      >
+        <GrabEditor />
+        <RichTextPlugin
+          contentEditable={<ContentEditable />}
+          placeholder={null}
+          ErrorBoundary={LexicalErrorBoundary}
+        />
+        <UsjNodesMenuPlugin
+          trigger="\\"
+          scrRef={scriptureReference}
+          getMarkerAction={getMarkerAction}
+        />
+      </LexicalComposer>
+    );
+  }
+
+  await act(async () => {
+    reactRoot.render(<App />);
+  });
+
+  // `editor` is on React render.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return { editor: editor!, verseToInsert };
+}
+
+/**
+ * Sets the selection range in the LexicalEditor.
+ *
+ * @param editor - The LexicalEditor instance where the selection will be set.
+ * @param verseToInsert - The verse to insert at the selection.
+ * @param startNode - The starting TextNode of the selection.
+ * @param startOffset - The offset within the startNode where the selection begins. Defaults to the end of the startNode's text content.
+ * @param endNode - The ending TextNode of the selection. Defaults to the startNode.
+ * @param endOffset - The offset within the endNode where the selection ends. Defaults to the startOffset.
+ */
+async function insertVerseNodeAtSelection(
+  editor: LexicalEditor,
+  verseToInsert: string,
+  startNode: TextNode,
+  startOffset?: number,
+  endNode?: TextNode,
+  endOffset?: number,
+) {
+  await act(async () => {
+    editor.update(() => {
+      if (!startOffset) startOffset = startNode.getTextContentSize();
+      if (!endNode) endNode = startNode;
+      if (!endOffset) endOffset = startOffset;
+      const rangeSelection = $createRangeSelection();
+      rangeSelection.anchor = $createPoint(startNode.getKey(), startOffset, "text");
+      rangeSelection.focus = $createPoint(endNode.getKey(), endOffset, "text");
+      $setSelection(rangeSelection);
+      rangeSelection.insertNodes([$createImmutableVerseNode(verseToInsert)]);
+    });
+  });
+}

--- a/packages/shared/nodes/features/TypedMarkNode.test.ts
+++ b/packages/shared/nodes/features/TypedMarkNode.test.ts
@@ -8,9 +8,9 @@ const testID2 = "testID2";
 
 describe("TypedMarkNode", () => {
   describe("hasID()", () => {
-    it("should work the specified type", async () => {
+    it("should work the specified type", () => {
       const { editor } = createBasicTestEnvironment([TypedMarkNode]);
-      await editor.update(() => {
+      editor.update(() => {
         const node = $createTypedMarkNode({
           [testType1]: [testID1, testID2],
           [testType2]: [testID2],
@@ -31,9 +31,9 @@ describe("TypedMarkNode", () => {
   });
 
   describe("addID()", () => {
-    it("should add IDs to the specified type", async () => {
+    it("should add IDs to the specified type", () => {
       const { editor } = createBasicTestEnvironment([TypedMarkNode]);
-      await editor.update(() => {
+      editor.update(() => {
         const node = $createTypedMarkNode({});
         expect(node).toBeDefined();
 
@@ -59,9 +59,9 @@ describe("TypedMarkNode", () => {
   });
 
   describe("deleteID()", () => {
-    it("should delete IDs from the specified type", async () => {
+    it("should delete IDs from the specified type", () => {
       const { editor } = createBasicTestEnvironment([TypedMarkNode]);
-      await editor.update(() => {
+      editor.update(() => {
         const node = $createTypedMarkNode({
           [testType1]: [testID1, testID2],
           [testType2]: [testID2],
@@ -90,9 +90,9 @@ describe("TypedMarkNode", () => {
   });
 
   describe("hasNoIDsForEveryType()", () => {
-    it("should work if has no types", async () => {
+    it("should work if has no types", () => {
       const { editor } = createBasicTestEnvironment([TypedMarkNode]);
-      await editor.update(() => {
+      editor.update(() => {
         const node = $createTypedMarkNode({});
         expect(node).toBeDefined();
 
@@ -100,9 +100,9 @@ describe("TypedMarkNode", () => {
       });
     });
 
-    it("should work if has types but no IDs", async () => {
+    it("should work if has types but no IDs", () => {
       const { editor } = createBasicTestEnvironment([TypedMarkNode]);
-      await editor.update(() => {
+      editor.update(() => {
         const node = $createTypedMarkNode({
           [testType1]: [],
           [testType2]: undefined as unknown as string[],
@@ -113,9 +113,9 @@ describe("TypedMarkNode", () => {
       });
     });
 
-    it("should work if has types and IDs", async () => {
+    it("should work if has types and IDs", () => {
       const { editor } = createBasicTestEnvironment([TypedMarkNode]);
-      await editor.update(() => {
+      editor.update(() => {
         const node = $createTypedMarkNode({
           [testType1]: [],
           [testType2]: [testID2],

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -56,6 +56,24 @@ Run `nx build utilities` to build the library.
 
 Run `nx test utilities` to execute the unit tests via [Jest](https://jestjs.io).
 
+## Develop in App
+
+To develop these utilities in a target application you can use [yalc](https://www.npmjs.com/package/yalc) to link the editor in without having to publish to NPM every time something changes.
+
+1. In this monorepo, publish the editor to `yalc`, e.g.:
+   ```bash
+   nx devpub utilities
+   ```
+2. In the target application repo, link from `yalc`:
+   ```bash
+   yalc link @biblionexus-foundation/scripture-utilities
+   ```
+3. In this monorepo, make changes and re-publish the editor (see step 1).
+4. When you have finished developing in the target application repo, unlink from `yalc`:
+   ```bash
+   yalc remove @biblionexus-foundation/scripture-utilities && npm i
+   ```
+
 ## License
 
 [MIT][github-license] © [BiblioNexus Foundation](https://biblionexus.org/)


### PR DESCRIPTION
- fix renumbering if only one chapter or is last chapter
- don't include `sid` for chapter or verse
- add a space before a verse if needed
- don't renumber if new USJ is loaded
- refactor to use node transform (remove bad cascading update)
- add tests and framework
- also add `utilities` develop-in-app instructions
- also remove redundant `await`s from tests