### PR TITLE
platform: part of PT-2248 cursor jump

### DIFF
--- a/packages/platform/src/editor/editor.css
+++ b/packages/platform/src/editor/editor.css
@@ -18,7 +18,6 @@
 .editor-inner {
   background: #fff;
   position: relative;
-  display: flex;
 }
 
 .editor-input {


### PR DESCRIPTION
- prevent `scrRef` updating again after the cursor has moved.
- also fix console warning about focus when `display: flex` on content editable element