### PR TITLE
generate callers without scroll

### DIFF
--- a/packages/platform/src/usj-nodes.css
+++ b/packages/platform/src/usj-nodes.css
@@ -2105,11 +2105,15 @@ body {
 }
 
 .editor-input {
-  counter-reset: caller 0;
+  counter-reset: caller;
+}
+
+.editor-input.reset-counters {
+  counter-reset: none;
 }
 
 .immutable-note-caller[data-caller="+"] {
-  counter-increment: caller 1;
+  counter-increment: caller;
 }
 
 .immutable-note-caller[data-caller="+"] > button::before {

--- a/packages/scribe/src/index.css
+++ b/packages/scribe/src/index.css
@@ -2122,11 +2122,15 @@ body {
 }
 
 .editor-input {
-  counter-reset: caller 0;
+  counter-reset: caller;
+}
+
+.editor-input.reset-counters {
+  counter-reset: none;
 }
 
 .immutable-note-caller[data-caller="+"] {
-  counter-increment: caller 1;
+  counter-increment: caller;
 }
 
 .immutable-note-caller[data-caller="+"] > button::before {

--- a/packages/shared-react/plugins/NoteNodePlugin.tsx
+++ b/packages/shared-react/plugins/NoteNodePlugin.tsx
@@ -141,13 +141,12 @@ function generateNoteCallersOnDestroy(
     const editorElement = document.querySelector<HTMLElement>(".editor-input");
     if (!nodeWasGenerated || !editorElement) continue;
 
-    const originalDisplay = editorElement.style.display;
-    editorElement.style.display = "none";
+    editorElement.classList.add("reset-counters");
 
     // Force a reflow to ensure the counter reset is applied
     void editorElement.offsetHeight;
 
-    editorElement.style.display = originalDisplay;
+    editorElement.classList.remove("reset-counters");
   }
 }
 


### PR DESCRIPTION
- when a note is removed, re-generate callers without scrolling the content editable to the top