### PR TITLE
use `typeMarkNodeName`

### DIFF
--- a/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor-adaptor.test.ts
@@ -1,5 +1,6 @@
 import { MarkerObject } from "@biblionexus-foundation/scripture-utilities";
 import { SerializedEditorState } from "lexical";
+import { typedMarkNodeName } from "shared/nodes/features/TypedMarkNode";
 import { SerializedParaNode } from "shared/nodes/scripture/usj/ParaNode";
 import { SerializedNoteNode } from "shared/nodes/scripture/usj/NoteNode";
 import {
@@ -7,7 +8,6 @@ import {
   immutableNoteCallerNodeName,
   SerializedImmutableNoteCallerNode,
 } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
-import { MarkNodeName } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 // Reaching inside only for tests.
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import {
@@ -121,7 +121,7 @@ describe("USJ Editor Adaptor", () => {
 
   it("should call `addMissingComments` if it's set", () => {
     const mockAddMissingComments = jest.fn();
-    const nodeOptions = { [MarkNodeName]: { addMissingComments: mockAddMissingComments } };
+    const nodeOptions = { [typedMarkNodeName]: { addMissingComments: mockAddMissingComments } };
     initialize(nodeOptions, console);
 
     const serializedEditorState = serializeEditorState(usjMarks);

--- a/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
@@ -27,6 +27,7 @@ import {
   COMMENT_MARK_TYPE,
   SerializedTypedMarkNode,
   TypedMarkNode,
+  typedMarkNodeName,
 } from "shared/nodes/features/TypedMarkNode";
 import {
   SerializedUnknownNode,
@@ -117,7 +118,6 @@ import {
 import { CallerData } from "shared-react/nodes/scripture/usj/node-react.utils";
 import {
   AddMissingComments,
-  MarkNodeName,
   UsjNodeOptions,
 } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import { ViewOptions, getVerseNodeClass, getViewOptions } from "./view-options.utils";
@@ -211,8 +211,8 @@ function setNodeOptions(nodeOptions: UsjNodeOptions | undefined) {
   if (nodeOptions) _nodeOptions = nodeOptions;
 
   // Set the `addMissingComments` method.
-  if (nodeOptions?.[MarkNodeName]?.addMissingComments) {
-    addMissingComments = nodeOptions[MarkNodeName].addMissingComments;
+  if (nodeOptions?.[typedMarkNodeName]?.addMissingComments) {
+    addMissingComments = nodeOptions[typedMarkNodeName].addMissingComments;
   }
 }
 

--- a/packages/platform/src/marginal/comments/use-missing-comments-props.hook.tsx
+++ b/packages/platform/src/marginal/comments/use-missing-comments-props.hook.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
-import { MarkNodeName } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import { LoggerBasic } from "shared/adaptors/logger-basic.model";
+import { typedMarkNodeName } from "shared/nodes/features/TypedMarkNode";
 import { CommentStore, Comments } from "./commenting";
 import { EditorProps } from "../../editor/Editor";
 
@@ -56,8 +56,9 @@ export default function useMissingCommentsProps<TLogger extends LoggerBasic>(
   useEffect(() => {
     if (!editorProps.options) editorProps.options = {};
     if (!editorProps.options.nodes) editorProps.options.nodes = {};
-    if (!editorProps.options.nodes[MarkNodeName]) editorProps.options.nodes[MarkNodeName] = {};
-    editorProps.options.nodes[MarkNodeName].addMissingComments = (usjCommentIds: string[]) => {
+    if (!editorProps.options.nodes[typedMarkNodeName])
+      editorProps.options.nodes[typedMarkNodeName] = {};
+    editorProps.options.nodes[typedMarkNodeName].addMissingComments = (usjCommentIds: string[]) => {
       addMissingComments(usjCommentIds, commentStoreRef);
     };
   }, [commentStoreRef, editorProps]);

--- a/packages/scribe/src/adaptors/usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/usj-editor.adaptor.ts
@@ -27,6 +27,7 @@ import {
   COMMENT_MARK_TYPE,
   SerializedTypedMarkNode,
   TypedMarkNode,
+  typedMarkNodeName,
 } from "shared/nodes/features/TypedMarkNode";
 import {
   SerializedUnknownNode,
@@ -117,7 +118,6 @@ import {
 import { CallerData } from "shared-react/nodes/scripture/usj/node-react.utils";
 import {
   AddMissingComments,
-  MarkNodeName,
   UsjNodeOptions,
 } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import { ViewOptions, getVerseNodeClass, getViewOptions } from "./view-options.utils";
@@ -211,8 +211,8 @@ function setNodeOptions(nodeOptions: UsjNodeOptions | undefined) {
   if (nodeOptions) _nodeOptions = nodeOptions;
 
   // Set the `addMissingComments` method.
-  if (nodeOptions?.[MarkNodeName]?.addMissingComments) {
-    addMissingComments = nodeOptions[MarkNodeName].addMissingComments;
+  if (nodeOptions?.[typedMarkNodeName]?.addMissingComments) {
+    addMissingComments = nodeOptions[typedMarkNodeName].addMissingComments;
   }
 }
 

--- a/packages/shared-react/nodes/scripture/usj/usj-node-options.model.ts
+++ b/packages/shared-react/nodes/scripture/usj/usj-node-options.model.ts
@@ -1,7 +1,6 @@
 import { NodeOptions } from "shared/adaptors/editor-adaptor.model";
+import { typedMarkNodeName } from "shared/nodes/features/TypedMarkNode";
 import { OnClick, immutableNoteCallerNodeName } from "./ImmutableNoteCallerNode";
-
-export const MarkNodeName = "MarkNode";
 
 export type AddMissingComments = (usjCommentIds: string[]) => void;
 
@@ -13,7 +12,7 @@ export interface UsjNodeOptions extends NodeOptions {
     /** Click handler method. */
     onClick?: OnClick;
   };
-  [MarkNodeName]?: {
+  [typedMarkNodeName]?: {
     /** Method to add missing comments. */
     addMissingComments?: AddMissingComments;
   };

--- a/packages/shared/nodes/features/TypedMarkNode.ts
+++ b/packages/shared/nodes/features/TypedMarkNode.ts
@@ -37,6 +37,8 @@ export type SerializedTypedMarkNode = Spread<
 
 /** Reserved type for CommentPlugin. */
 export const COMMENT_MARK_TYPE = "comment";
+export const typedMarkNodeName = "TypedMarkNode";
+
 const reservedTypes = [COMMENT_MARK_TYPE];
 const TYPED_MARK_VERSION = 1;
 


### PR DESCRIPTION
- instead of `MarkNodeName`, missed change in earlier refactor