### PR TITLE
simplify marker types

### DIFF
--- a/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
+++ b/packages/platform/src/editor/adaptors/usj-editor.adaptor.ts
@@ -63,19 +63,13 @@ import {
 import {
   MILESTONE_VERSION,
   MilestoneNode,
-  MilestoneMarker,
   SerializedMilestoneNode,
   STARTING_MS_COMMENT_MARKER,
   ENDING_MS_COMMENT_MARKER,
   isMilestoneCommentMarker,
 } from "shared/nodes/scripture/usj/MilestoneNode";
-import {
-  NOTE_VERSION,
-  NoteNode,
-  NoteMarker,
-  SerializedNoteNode,
-} from "shared/nodes/scripture/usj/NoteNode";
-import { NBSP } from "shared/nodes/scripture/usj/node-constants";
+import { NOTE_VERSION, NoteNode, SerializedNoteNode } from "shared/nodes/scripture/usj/NoteNode";
+import { NBSP, PARA_MARKER_DEFAULT } from "shared/nodes/scripture/usj/node-constants";
 import {
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
@@ -87,7 +81,6 @@ import {
 } from "shared/nodes/scripture/usj/node.utils";
 import {
   isSerializedParaNode,
-  PARA_MARKER_DEFAULT,
   PARA_VERSION,
   ParaNode,
   SerializedParaNode,
@@ -436,7 +429,7 @@ function createNote(
 
   return removeUndefinedProperties({
     type: NoteNode.getType(),
-    marker: marker as NoteMarker,
+    marker,
     caller,
     category,
     unknownAttributes,
@@ -457,7 +450,7 @@ function createMilestone(markerObject: MarkerObject): SerializedMilestoneNode {
 
   return removeUndefinedProperties({
     type: MilestoneNode.getType(),
-    marker: marker as MilestoneMarker,
+    marker,
     sid,
     eid,
     unknownAttributes,

--- a/packages/scribe/src/adaptors/note-usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/note-usj-editor.adaptor.ts
@@ -52,25 +52,13 @@ import {
 import {
   MILESTONE_VERSION,
   MilestoneNode,
-  MilestoneMarker,
   SerializedMilestoneNode,
   STARTING_MS_COMMENT_MARKER,
   ENDING_MS_COMMENT_MARKER,
   isMilestoneCommentMarker,
 } from "shared/nodes/scripture/usj/MilestoneNode";
-import {
-  PARA_MARKER_DEFAULT,
-  PARA_VERSION,
-  ParaNode,
-  SerializedParaNode,
-} from "shared/nodes/scripture/usj/ParaNode";
-import {
-  NOTE_VERSION,
-  NoteNode,
-  NoteMarker,
-  SerializedNoteNode,
-} from "shared/nodes/scripture/usj/NoteNode";
-import { NBSP } from "shared/nodes/scripture/usj/node-constants";
+import { NOTE_VERSION, NoteNode, SerializedNoteNode } from "shared/nodes/scripture/usj/NoteNode";
+import { NBSP, PARA_MARKER_DEFAULT } from "shared/nodes/scripture/usj/node-constants";
 import {
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
@@ -79,6 +67,7 @@ import {
   isSerializedTextNode,
   removeUndefinedProperties,
 } from "shared/nodes/scripture/usj/node.utils";
+import { PARA_VERSION, ParaNode, SerializedParaNode } from "shared/nodes/scripture/usj/ParaNode";
 import {
   SerializedVerseNode,
   VERSE_MARKER,
@@ -420,7 +409,7 @@ function createNote(
 
   return removeUndefinedProperties({
     type: NoteNode.getType(),
-    marker: marker as NoteMarker,
+    marker,
     caller,
     category,
     unknownAttributes,
@@ -441,7 +430,7 @@ function createMilestone(markerObject: MarkerObject): SerializedMilestoneNode {
 
   return removeUndefinedProperties({
     type: MilestoneNode.getType(),
-    marker: marker as MilestoneMarker,
+    marker,
     sid,
     eid,
     unknownAttributes,

--- a/packages/scribe/src/adaptors/usj-editor.adaptor.ts
+++ b/packages/scribe/src/adaptors/usj-editor.adaptor.ts
@@ -63,19 +63,13 @@ import {
 import {
   MILESTONE_VERSION,
   MilestoneNode,
-  MilestoneMarker,
   SerializedMilestoneNode,
   STARTING_MS_COMMENT_MARKER,
   ENDING_MS_COMMENT_MARKER,
   isMilestoneCommentMarker,
 } from "shared/nodes/scripture/usj/MilestoneNode";
-import {
-  NOTE_VERSION,
-  NoteNode,
-  NoteMarker,
-  SerializedNoteNode,
-} from "shared/nodes/scripture/usj/NoteNode";
-import { NBSP } from "shared/nodes/scripture/usj/node-constants";
+import { NOTE_VERSION, NoteNode, SerializedNoteNode } from "shared/nodes/scripture/usj/NoteNode";
+import { NBSP, PARA_MARKER_DEFAULT } from "shared/nodes/scripture/usj/node-constants";
 import {
   getEditableCallerText,
   getPreviewTextFromSerializedNodes,
@@ -87,7 +81,6 @@ import {
 } from "shared/nodes/scripture/usj/node.utils";
 import {
   isSerializedParaNode,
-  PARA_MARKER_DEFAULT,
   PARA_VERSION,
   ParaNode,
   SerializedParaNode,
@@ -436,7 +429,7 @@ function createNote(
 
   return removeUndefinedProperties({
     type: NoteNode.getType(),
-    marker: marker as NoteMarker,
+    marker,
     caller,
     category,
     unknownAttributes,
@@ -457,7 +450,7 @@ function createMilestone(markerObject: MarkerObject): SerializedMilestoneNode {
 
   return removeUndefinedProperties({
     type: MilestoneNode.getType(),
-    marker: marker as MilestoneMarker,
+    marker,
     sid,
     eid,
     unknownAttributes,

--- a/packages/shared/nodes/features/MarkerNode.ts
+++ b/packages/shared/nodes/features/MarkerNode.ts
@@ -16,19 +16,17 @@ export const MARKER_VERSION = 1;
 
 export type SerializedMarkerNode = Spread<
   {
-    marker: MarkerMarker;
+    marker: string;
     isOpening?: boolean;
   },
   SerializedTextNode
 >;
 
-type MarkerMarker = string;
-
 export class MarkerNode extends TextNode {
-  __marker: MarkerMarker;
+  __marker: string;
   __isOpening: boolean;
 
-  constructor(marker: MarkerMarker, isOpening = true, key?: NodeKey) {
+  constructor(marker: string, isOpening = true, key?: NodeKey) {
     const text = isOpening ? openingMarkerText(marker) : closingMarkerText(marker);
     super(text, key);
     this.__marker = marker;
@@ -48,7 +46,7 @@ export class MarkerNode extends TextNode {
     return $createMarkerNode(marker, isOpening).updateFromJSON(serializedNode);
   }
 
-  setMarker(marker: MarkerMarker): this {
+  setMarker(marker: string): this {
     if (this.__marker === marker) return this;
 
     const self = this.getWritable();
@@ -56,7 +54,7 @@ export class MarkerNode extends TextNode {
     return self;
   }
 
-  getMarker(): MarkerMarker {
+  getMarker(): string {
     const self = this.getLatest();
     return self.__marker;
   }
@@ -93,7 +91,7 @@ export class MarkerNode extends TextNode {
   }
 }
 
-export function $createMarkerNode(marker: MarkerMarker, isOpening?: boolean): MarkerNode {
+export function $createMarkerNode(marker: string, isOpening?: boolean): MarkerNode {
   return $applyNodeReplacement(new MarkerNode(marker, isOpening));
 }
 

--- a/packages/shared/nodes/scripture/usj/ImpliedParaNode.ts
+++ b/packages/shared/nodes/scripture/usj/ImpliedParaNode.ts
@@ -8,7 +8,7 @@ import {
   SerializedLexicalNode,
   SerializedParagraphNode,
 } from "lexical";
-import { PARA_MARKER_DEFAULT } from "./ParaNode";
+import { PARA_MARKER_DEFAULT } from "./node-constants";
 
 export const IMPLIED_PARA_VERSION = 1;
 

--- a/packages/shared/nodes/scripture/usj/MilestoneNode.ts
+++ b/packages/shared/nodes/scripture/usj/MilestoneNode.ts
@@ -42,11 +42,9 @@ const VALID_MILESTONE_MARKERS = [
 
 export const MILESTONE_VERSION = 1;
 
-export type MilestoneMarker = (typeof VALID_MILESTONE_MARKERS)[number];
-
 export type SerializedMilestoneNode = Spread<
   {
-    marker: MilestoneMarker;
+    marker: string;
     sid?: string;
     eid?: string;
     unknownAttributes?: UnknownAttributes;
@@ -55,13 +53,13 @@ export type SerializedMilestoneNode = Spread<
 >;
 
 export class MilestoneNode extends DecoratorNode<void> {
-  __marker: MilestoneMarker;
+  __marker: string;
   __sid?: string;
   __eid?: string;
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    marker: MilestoneMarker,
+    marker: string,
     sid?: string,
     eid?: string,
     unknownAttributes?: UnknownAttributes,
@@ -90,12 +88,13 @@ export class MilestoneNode extends DecoratorNode<void> {
 
   static isValidMarker(marker: string | undefined): boolean {
     return (
-      !!marker &&
-      (VALID_MILESTONE_MARKERS.includes(marker as MilestoneMarker) || marker.startsWith("z"))
+      marker !== undefined &&
+      (VALID_MILESTONE_MARKERS.includes(marker as (typeof VALID_MILESTONE_MARKERS)[number]) ||
+        marker.startsWith("z"))
     );
   }
 
-  setMarker(marker: MilestoneMarker): this {
+  setMarker(marker: string): this {
     if (this.__marker === marker) return this;
 
     const self = this.getWritable();
@@ -103,7 +102,7 @@ export class MilestoneNode extends DecoratorNode<void> {
     return self;
   }
 
-  getMarker(): MilestoneMarker {
+  getMarker(): string {
     const self = this.getLatest();
     return self.__marker;
   }
@@ -179,7 +178,7 @@ export function isMilestoneCommentMarker(marker: string) {
 }
 
 export function $createMilestoneNode(
-  marker: MilestoneMarker,
+  marker: string,
   sid?: string,
   eid?: string,
   unknownAttributes?: UnknownAttributes,

--- a/packages/shared/nodes/scripture/usj/NoteNode.ts
+++ b/packages/shared/nodes/scripture/usj/NoteNode.ts
@@ -27,11 +27,9 @@ const VALID_NOTE_MARKERS = [
   "ex",
 ] as const;
 
-export type NoteMarker = (typeof VALID_NOTE_MARKERS)[number];
-
 export type SerializedNoteNode = Spread<
   {
-    marker: NoteMarker;
+    marker: string;
     caller: string;
     category?: string;
     unknownAttributes?: UnknownAttributes;
@@ -43,13 +41,13 @@ export const NOTE_VERSION = 1;
 
 export const noteNodeName = "NoteNode";
 export class NoteNode extends ElementNode {
-  __marker: NoteMarker;
+  __marker: string;
   __caller: string;
   __category?: string;
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    marker: NoteMarker,
+    marker: string,
     caller: string,
     category?: string,
     unknownAttributes?: UnknownAttributes,
@@ -92,10 +90,13 @@ export class NoteNode extends ElementNode {
   }
 
   static isValidMarker(marker: string | undefined): boolean {
-    return !!marker && VALID_NOTE_MARKERS.includes(marker as NoteMarker);
+    return (
+      marker !== undefined &&
+      VALID_NOTE_MARKERS.includes(marker as (typeof VALID_NOTE_MARKERS)[number])
+    );
   }
 
-  setMarker(marker: NoteMarker): this {
+  setMarker(marker: string): this {
     if (this.__marker === marker) return this;
 
     const self = this.getWritable();
@@ -103,7 +104,7 @@ export class NoteNode extends ElementNode {
     return self;
   }
 
-  getMarker(): NoteMarker {
+  getMarker(): string {
     const self = this.getLatest();
     return self.__marker;
   }
@@ -194,14 +195,14 @@ export class NoteNode extends ElementNode {
 }
 
 function $convertNoteElement(element: HTMLElement): DOMConversionOutput {
-  const marker = (element.getAttribute("data-marker") as NoteMarker) ?? "f";
+  const marker = element.getAttribute("data-marker") ?? "f";
   const caller = element.getAttribute("data-caller") ?? "";
   const node = $createNoteNode(marker, caller);
   return { node };
 }
 
 export function $createNoteNode(
-  marker: NoteMarker,
+  marker: string,
   caller: string,
   category?: string,
   unknownAttributes?: UnknownAttributes,

--- a/packages/shared/nodes/scripture/usj/ParaNode.ts
+++ b/packages/shared/nodes/scripture/usj/ParaNode.ts
@@ -16,14 +16,7 @@ import {
   Spread,
   isHTMLElement,
 } from "lexical";
-import { UnknownAttributes } from "./node-constants";
-import {
-  extractNonNumberedMarkers,
-  extractNumberedMarkers,
-  isValidNumberedMarker,
-} from "./node.utils";
-
-export const PARA_MARKER_DEFAULT = "p";
+import { PARA_MARKER_DEFAULT, UnknownAttributes } from "./node-constants";
 
 /** @see https://docs.usfm.bible/usfm/3.1/para/index.html */
 const VALID_PARA_MARKERS = [
@@ -154,31 +147,22 @@ const VALID_PARA_MARKERS = [
   "pb",
 ] as const;
 
-const VALID_PARA_MARKERS_NUMBERED = extractNumberedMarkers(VALID_PARA_MARKERS);
-const VALID_PARA_MARKERS_NON_NUMBERED = [
-  ...extractNonNumberedMarkers(VALID_PARA_MARKERS),
-  // Include the numbered styles, i.e. not ending in a number since pi (= pi1) is valid.
-  ...VALID_PARA_MARKERS_NUMBERED,
-] as const;
-
 export const PARA_VERSION = 1;
 
 export type SerializedParaNode = Spread<
   {
-    marker: ParaMarker;
+    marker: string;
     unknownAttributes?: UnknownAttributes;
   },
   SerializedParagraphNode
 >;
 
-type ParaMarker = string;
-
 export class ParaNode extends ParagraphNode {
-  __marker: ParaMarker;
+  __marker: string;
   __unknownAttributes?: UnknownAttributes;
 
   constructor(
-    marker: ParaMarker = PARA_MARKER_DEFAULT,
+    marker: string = PARA_MARKER_DEFAULT,
     unknownAttributes?: UnknownAttributes,
     key?: NodeKey,
   ) {
@@ -212,12 +196,12 @@ export class ParaNode extends ParagraphNode {
 
   static isValidMarker(marker: string | undefined): boolean {
     return (
-      (marker && VALID_PARA_MARKERS_NON_NUMBERED.includes(marker)) ||
-      isValidNumberedMarker(marker, VALID_PARA_MARKERS_NUMBERED)
+      marker !== undefined &&
+      VALID_PARA_MARKERS.includes(marker as (typeof VALID_PARA_MARKERS)[number])
     );
   }
 
-  setMarker(marker: ParaMarker): this {
+  setMarker(marker: string): this {
     if (this.__marker === marker) return this;
 
     const self = this.getWritable();
@@ -225,7 +209,7 @@ export class ParaNode extends ParagraphNode {
     return self;
   }
 
-  getMarker(): ParaMarker {
+  getMarker(): string {
     const self = this.getLatest();
     return self.__marker;
   }
@@ -297,10 +281,7 @@ function $convertParaElement(element: HTMLElement): DOMConversionOutput {
   return { node };
 }
 
-export function $createParaNode(
-  marker?: ParaMarker,
-  unknownAttributes?: UnknownAttributes,
-): ParaNode {
+export function $createParaNode(marker?: string, unknownAttributes?: UnknownAttributes): ParaNode {
   return $applyNodeReplacement(new ParaNode(marker, unknownAttributes));
 }
 

--- a/packages/shared/nodes/scripture/usj/node-constants.ts
+++ b/packages/shared/nodes/scripture/usj/node-constants.ts
@@ -2,7 +2,7 @@
 
 export type UnknownAttributes = { [name: string]: string | undefined };
 
-export const NUMBERED_MARKER_PLACEHOLDER = "#";
+export const PARA_MARKER_DEFAULT = "p";
 
 export const NBSP = "\u00A0";
 export const ZWSP = "\u200B";

--- a/packages/shared/nodes/scripture/usj/node-utils.test.ts
+++ b/packages/shared/nodes/scripture/usj/node-utils.test.ts
@@ -3,8 +3,6 @@ import { $getRoot, NodeKey, $getNodeByKey } from "lexical";
 import { $createImmutableChapterNode } from "./ImmutableChapterNode";
 import { $createParaNode } from "./ParaNode";
 import {
-  extractNonNumberedMarkers,
-  extractNumberedMarkers,
   getNextVerse,
   getUnknownAttributes,
   isValidNumberedMarker,
@@ -31,26 +29,6 @@ describe("Editor Node Utilities", () => {
 
     it("should not identify a non-numbered marker", async () => {
       expect(isValidNumberedMarker("pi", ["pi"])).toBe(false);
-    });
-  });
-
-  describe("extractNumberedMarkers()", () => {
-    it("should not throw", async () => {
-      expect(() => extractNumberedMarkers([undefined as unknown as string])).not.toThrow();
-    });
-
-    it("should extract numbered markers", async () => {
-      expect(extractNumberedMarkers(["p", "pi#"])).toEqual(["pi"]);
-    });
-  });
-
-  describe("extractNonNumberedMarkers()", () => {
-    it("should not throw", async () => {
-      expect(() => extractNonNumberedMarkers([undefined as unknown as string])).not.toThrow();
-    });
-
-    it("should extract non-numbered markers", async () => {
-      expect(extractNonNumberedMarkers(["p", "pi#"])).toEqual(["p"]);
     });
   });
 

--- a/packages/shared/nodes/scripture/usj/node.utils.ts
+++ b/packages/shared/nodes/scripture/usj/node.utils.ts
@@ -11,8 +11,6 @@ import {
   SerializedTextNode,
   TextNode,
 } from "lexical";
-// Must be imported before `CharNode` to prevent a circular dependency.
-import { NBSP, NUMBERED_MARKER_PLACEHOLDER, UnknownAttributes } from "./node-constants";
 import { $isUnknownNode, UnknownNode } from "../../features/UnknownNode";
 import { $isBookNode, BookNode } from "./BookNode";
 import {
@@ -31,6 +29,7 @@ import {
 import { $isImpliedParaNode, ImpliedParaNode } from "./ImpliedParaNode";
 import { $isMilestoneNode, MilestoneNode } from "./MilestoneNode";
 import { $isNoteNode, NoteNode } from "./NoteNode";
+import { NBSP, UnknownAttributes } from "./node-constants";
 import { $isParaNode, ParaNode } from "./ParaNode";
 import { $isVerseNode, VerseNode } from "./VerseNode";
 
@@ -73,30 +72,6 @@ export function isValidNumberedMarker(
   // Ends with a number.
   const maybeNumber = marker.slice(numberedMarker.length);
   return ONLY_DIGITS_TEST.test(maybeNumber);
-}
-
-/**
- * Extracts a list of numbered markers with the '#' removed.
- * @param markers - List of markers containing placeholder numbered markers, e.g. ['p', 'pi#'].
- * @returns list of numbered markers (non-numbered are filtered out) with the '#' removed,
- *   e.g. ['pi'].
- */
-export function extractNumberedMarkers(markers: string[] | readonly string[]): string[] {
-  return (
-    markers
-      .filter((marker) => !!marker && marker.endsWith(NUMBERED_MARKER_PLACEHOLDER))
-      // remove placeholder
-      .map((marker) => marker.slice(0, -1))
-  );
-}
-
-/**
- * Extracts a list of non-numbered markers.
- * @param markers - List of markers containing placeholder numbered markers, e.g. ['p', 'pi#'].
- * @returns list of non-numbered markers (numbered are filtered out), e.g. ['p'].
- */
-export function extractNonNumberedMarkers(markers: string[] | readonly string[]): string[] {
-  return markers.filter((marker) => !marker?.endsWith(NUMBERED_MARKER_PLACEHOLDER));
 }
 
 /**


### PR DESCRIPTION
- use `string` types for customizable markers
- remove generic numbered markers (markers containing '#')