### PR TITLE
platform: arrow key navigation

### DIFF
--- a/packages/platform/src/editor/Editor.tsx
+++ b/packages/platform/src/editor/Editor.tsx
@@ -18,6 +18,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { LoggerBasic } from "shared/adaptors/logger-basic.model";
 import { TypedMarkNode } from "shared/nodes/features/TypedMarkNode";
 import scriptureUsjNodes from "shared/nodes/scripture/usj";
 import {
@@ -33,12 +34,12 @@ import {
 import { ImmutableNoteCallerNode } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
 import { ImmutableVerseNode } from "shared-react/nodes/scripture/usj/ImmutableVerseNode";
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
+import { ArrowNavigationPlugin } from "shared-react/plugins/ArrowNavigationPlugin";
 import ClipboardPlugin from "shared-react/plugins/ClipboardPlugin";
 import CommandMenuPlugin from "shared-react/plugins/CommandMenuPlugin";
 import ContextMenuPlugin from "shared-react/plugins/ContextMenuPlugin";
 import EditablePlugin from "shared-react/plugins/EditablePlugin";
-import { LoggerBasic } from "shared/adaptors/logger-basic.model";
-import NoteNodePlugin from "shared-react/plugins/NoteNodePlugin";
+import { NoteNodePlugin } from "shared-react/plugins/NoteNodePlugin";
 import OnSelectionChangePlugin from "shared-react/plugins/OnSelectionChangePlugin";
 import ParaNodePlugin from "shared-react/plugins/ParaNodePlugin";
 import TextDirectionPlugin from "shared-react/plugins/TextDirectionPlugin";
@@ -282,6 +283,7 @@ const Editor = forwardRef(function Editor<TLogger extends LoggerBasic>(
             ignoreHistoryMergeTagChange
           />
           <AnnotationPlugin ref={annotationRef} logger={logger} />
+          <ArrowNavigationPlugin />
           <ClipboardPlugin />
           <CommandMenuPlugin logger={logger} />
           <ContextMenuPlugin />

--- a/packages/scribe/src/components/Editor.tsx
+++ b/packages/scribe/src/components/Editor.tsx
@@ -15,7 +15,7 @@ import { ImmutableVerseNode } from "shared-react/nodes/scripture/usj/ImmutableVe
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
 import ClipboardPlugin from "shared-react/plugins/ClipboardPlugin";
 import ContextMenuPlugin from "shared-react/plugins/ContextMenuPlugin";
-import NoteNodePlugin from "shared-react/plugins/NoteNodePlugin";
+import { NoteNodePlugin } from "shared-react/plugins/NoteNodePlugin";
 import UpdateStatePlugin from "shared-react/plugins/UpdateStatePlugin";
 import editorUsjAdaptor from "../adaptors/editor-usj.adaptor";
 import { getViewClassList, ViewOptions } from "../adaptors/view-options.utils";

--- a/packages/scribe/src/components/NoteEditor.tsx
+++ b/packages/scribe/src/components/NoteEditor.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect } from "react";
 import scriptureUsjNodes from "shared/nodes/scripture/usj";
 import { ImmutableNoteCallerNode } from "shared-react/nodes/scripture/usj/ImmutableNoteCallerNode";
 import { UsjNodeOptions } from "shared-react/nodes/scripture/usj/usj-node-options.model";
-import NoteNodePlugin from "shared-react/plugins/NoteNodePlugin";
+import { NoteNodePlugin } from "shared-react/plugins/NoteNodePlugin";
 import UpdateStatePlugin from "shared-react/plugins/UpdateStatePlugin";
 import editorUsjAdaptor from "../adaptors/editor-usj.adaptor";
 import usjNoteEditorAdapter from "../adaptors/note-usj-editor.adaptor";

--- a/packages/shared-react/nodes/scripture/usj/ImmutableVerseNode.tsx
+++ b/packages/shared-react/nodes/scripture/usj/ImmutableVerseNode.tsx
@@ -14,7 +14,11 @@ import {
   isHTMLElement,
 } from "lexical";
 import { JSX } from "react";
-import { UnknownAttributes, VERSE_CLASS_NAME } from "shared/nodes/scripture/usj/node-constants";
+import {
+  UnknownAttributes,
+  VERSE_CLASS_NAME,
+  ZWSP,
+} from "shared/nodes/scripture/usj/node-constants";
 import { getVisibleOpenMarkerText } from "shared/nodes/scripture/usj/node.utils";
 
 export const VERSE_MARKER = "v";
@@ -209,7 +213,8 @@ export class ImmutableVerseNode extends DecoratorNode<JSX.Element> {
       <span>
         {this.getShowMarker()
           ? getVisibleOpenMarkerText(this.getMarker(), this.getNumber())
-          : this.getNumber()}
+          : // ZWSP added so double click word selection works without including this number.
+            ZWSP + this.getNumber() + ZWSP}
       </span>
     );
   }

--- a/packages/shared-react/plugins/ArrowNavigationPlugin.test.tsx
+++ b/packages/shared-react/plugins/ArrowNavigationPlugin.test.tsx
@@ -1,0 +1,305 @@
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { render, act } from "@testing-library/react";
+import { $createTextNode, $getRoot, LexicalEditor, TextNode } from "lexical";
+import scriptureUsjNodes from "shared/nodes/scripture/usj";
+import { $createCharNode } from "shared/nodes/scripture/usj/CharNode";
+import { $createImmutableChapterNode } from "shared/nodes/scripture/usj/ImmutableChapterNode";
+import { $createNoteNode } from "shared/nodes/scripture/usj/NoteNode";
+import { $createParaNode, ParaNode } from "shared/nodes/scripture/usj/ParaNode";
+import { $expectSelectionToBe, pressArrowKey, updateSelection } from "shared/nodes/test.utils";
+import {
+  $createImmutableNoteCallerNode,
+  ImmutableNoteCallerNode,
+} from "../nodes/scripture/usj/ImmutableNoteCallerNode";
+import {
+  $createImmutableVerseNode,
+  ImmutableVerseNode,
+} from "../nodes/scripture/usj/ImmutableVerseNode";
+import { ArrowNavigationPlugin } from "./ArrowNavigationPlugin";
+import TextDirectionPlugin from "./TextDirectionPlugin";
+
+let paraNodeBeforeChapter: ParaNode;
+let textNodeBeforeChapter: TextNode;
+let paraNodeAfterChapter: ParaNode;
+let textNodeAfterChapter: TextNode;
+let verseParaNode: ParaNode;
+let firstVerseTextNode: TextNode;
+let secondVerseTextNodeBeforeNote: TextNode;
+let secondVerseTextNodeAfterNote: TextNode;
+let note2TextNode: TextNode;
+let thirdVerseTextNode: TextNode;
+
+function $defaultInitialEditorState() {
+  paraNodeBeforeChapter = $createParaNode("cl");
+  textNodeBeforeChapter = $createTextNode("Before Chapter");
+  paraNodeAfterChapter = $createParaNode("ms");
+  textNodeAfterChapter = $createTextNode("After Chapter");
+  verseParaNode = $createParaNode();
+  firstVerseTextNode = $createTextNode("verse1 text ");
+  secondVerseTextNodeBeforeNote = $createTextNode("verse2 text before note ");
+  secondVerseTextNodeAfterNote = $createTextNode("verse2 text after note ");
+  note2TextNode = $createTextNode("note2 text");
+  thirdVerseTextNode = $createTextNode("verse3 text ");
+  $getRoot().append(
+    paraNodeBeforeChapter.append(textNodeBeforeChapter),
+    $createImmutableChapterNode("1"),
+    paraNodeAfterChapter.append(textNodeAfterChapter),
+    verseParaNode.append(
+      $createImmutableVerseNode("1"),
+      firstVerseTextNode,
+      $createImmutableVerseNode("2"),
+      secondVerseTextNodeBeforeNote,
+      $createNoteNode("f", "+").append(
+        $createImmutableNoteCallerNode("+", "note1 preview"),
+        $createCharNode("ft").append($createTextNode("note1 text")),
+      ),
+      secondVerseTextNodeAfterNote,
+      $createImmutableVerseNode("3"),
+      $createNoteNode("f", "+").append(
+        $createImmutableNoteCallerNode("+", "note2 preview"),
+        $createCharNode("ft").append(note2TextNode),
+      ),
+      thirdVerseTextNode,
+      $createImmutableVerseNode("4"),
+    ),
+  );
+}
+
+describe("ArrowNavigationPlugin", () => {
+  describe("LTR Direction", () => {
+    describe("ArrowRight", () => {
+      it("should skip over ImmutableChapterNode when moving forward", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, textNodeBeforeChapter);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(paraNodeAfterChapter, 0);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode when moving forward across paras", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, verseParaNode, 0);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(firstVerseTextNode, 0);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode when moving forward inline", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, firstVerseTextNode);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(secondVerseTextNodeBeforeNote, 0);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode and following NoteNode when moving forward", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, secondVerseTextNodeAfterNote);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(note2TextNode);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode at the end of a para when moving forward", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, thirdVerseTextNode);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(verseParaNode, 10);
+        });
+      });
+    });
+
+    describe("ArrowLeft", () => {
+      it("should skip over ImmutableChapterNode when moving backward", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, textNodeAfterChapter, 0);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(paraNodeBeforeChapter, 1);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode when moving backward across paras", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, firstVerseTextNode, 0);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(verseParaNode, 0);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode when moving backward inline", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, secondVerseTextNodeBeforeNote, 0);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(firstVerseTextNode);
+        });
+      });
+
+      it("should skip over NoteNode and preceding ImmutableVerseNode when moving backward", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, thirdVerseTextNode, 0);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(secondVerseTextNodeAfterNote);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode at the end of a para when moving backward", async () => {
+        const { editor } = await testEnvironment();
+        updateSelection(editor, verseParaNode, 10);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(thirdVerseTextNode);
+        });
+      });
+    });
+  });
+
+  describe("RTL Direction (basic tests only)", () => {
+    describe("ArrowLeft (Forward)", () => {
+      it("should skip over ImmutableChapterNode when moving forward (RTL)", async () => {
+        const { editor } = await testEnvironment(undefined, "rtl");
+        updateSelection(editor, textNodeBeforeChapter);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(paraNodeAfterChapter, 0);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode when moving forward (RTL)", async () => {
+        const { editor } = await testEnvironment(undefined, "rtl");
+        updateSelection(editor, firstVerseTextNode);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(secondVerseTextNodeBeforeNote, 0);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode and following NoteNode when moving forward (RTL)", async () => {
+        const { editor } = await testEnvironment(undefined, "rtl");
+        updateSelection(editor, secondVerseTextNodeAfterNote);
+
+        await pressArrowKey(editor, "ArrowLeft");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(note2TextNode);
+        });
+      });
+    });
+
+    describe("ArrowRight (Backward)", () => {
+      it("should skip over ImmutableChapterNode when moving backward (RTL)", async () => {
+        const { editor } = await testEnvironment(undefined, "rtl");
+        updateSelection(editor, textNodeAfterChapter, 0);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(paraNodeBeforeChapter, 1);
+        });
+      });
+
+      it("should skip over ImmutableVerseNode when moving backward (RTL)", async () => {
+        const { editor } = await testEnvironment(undefined, "rtl");
+        updateSelection(editor, secondVerseTextNodeBeforeNote, 0);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(firstVerseTextNode);
+        });
+      });
+
+      it("should skip over NoteNode and preceding ImmutableVerseNode when moving backward (RTL)", async () => {
+        const { editor } = await testEnvironment(undefined, "rtl");
+        updateSelection(editor, thirdVerseTextNode, 0);
+
+        await pressArrowKey(editor, "ArrowRight");
+
+        editor.getEditorState().read(() => {
+          $expectSelectionToBe(secondVerseTextNodeAfterNote);
+        });
+      });
+    });
+  });
+});
+
+async function testEnvironment(
+  $initialEditorState: () => void = $defaultInitialEditorState,
+  textDirection: "ltr" | "rtl" = "ltr",
+) {
+  let editor: LexicalEditor;
+
+  function GrabEditor() {
+    [editor] = useLexicalComposerContext();
+    return null;
+  }
+
+  function App() {
+    return (
+      <LexicalComposer
+        initialConfig={{
+          editorState: $initialEditorState,
+          namespace: "TestEditor",
+          nodes: [ImmutableNoteCallerNode, ImmutableVerseNode, ...scriptureUsjNodes],
+          onError: () => {
+            throw Error();
+          },
+          theme: {},
+        }}
+      >
+        <GrabEditor />
+        <RichTextPlugin
+          contentEditable={<ContentEditable />}
+          placeholder={null}
+          ErrorBoundary={LexicalErrorBoundary}
+        />
+        <ArrowNavigationPlugin />
+        <TextDirectionPlugin textDirection={textDirection} />
+      </LexicalComposer>
+    );
+  }
+
+  await act(async () => {
+    render(<App />);
+  });
+
+  // `editor` is defined on React render.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return { editor: editor! };
+}

--- a/packages/shared-react/plugins/ArrowNavigationPlugin.tsx
+++ b/packages/shared-react/plugins/ArrowNavigationPlugin.tsx
@@ -1,0 +1,133 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_HIGH,
+  KEY_DOWN_COMMAND,
+  LexicalEditor,
+  LexicalNode,
+  RangeSelection,
+} from "lexical";
+import { useEffect } from "react";
+import {
+  $isImmutableChapterNode,
+  ImmutableChapterNode,
+} from "shared/nodes/scripture/usj/ImmutableChapterNode";
+import {
+  $isImmutableVerseNode,
+  ImmutableVerseNode,
+} from "../nodes/scripture/usj/ImmutableVerseNode";
+import { $isNoteNode, NoteNode } from "shared/nodes/scripture/usj/NoteNode";
+import { $getNextNode, $getPreviousNode } from "shared/nodes/scripture/usj/node.utils";
+import { $isParaNode } from "shared/nodes/scripture/usj/ParaNode";
+
+export function ArrowNavigationPlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  useArrowKeys(editor);
+  return null;
+}
+
+/**
+ * When moving with arrow keys, if a chapter or verse node is next, move to the following node.
+ * Also handles navigation around adjacent verse/note nodes.
+ * @param editor - The LexicalEditor instance used to access the DOM.
+ */
+function useArrowKeys(editor: LexicalEditor) {
+  useEffect(() => {
+    if (!editor.hasNodes([ImmutableChapterNode, ImmutableVerseNode, NoteNode])) {
+      throw new Error(
+        "ArrowNavigationPlugin: ImmutableChapterNode, ImmutableVerseNode or NoteNode not registered on editor!",
+      );
+    }
+
+    const $handleKeyDown = (event: KeyboardEvent): boolean => {
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return false;
+
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) return false;
+
+      const inputDiv = editor.getRootElement();
+      if (!inputDiv) return false;
+
+      const anchorNode = selection.anchor.getNode();
+      const direction = inputDiv.dir || "ltr";
+      const isMovingForward = checkIsMovingForward(direction, event.key);
+      const isMovingBackward = checkIsMovingBackward(direction, event.key);
+
+      let isHandled = false;
+
+      if (isMovingForward && $canMoveForward(anchorNode, selection)) {
+        isHandled = $handleForwardNavigation(anchorNode);
+      } else if (isMovingBackward && $canMoveBackward(anchorNode, selection)) {
+        isHandled = $handleBackwardNavigation(anchorNode);
+      }
+
+      if (isHandled) {
+        event.preventDefault();
+        return true;
+      }
+
+      return false;
+    };
+
+    return editor.registerCommand(KEY_DOWN_COMMAND, $handleKeyDown, COMMAND_PRIORITY_HIGH);
+  }, [editor]);
+}
+
+// --- Helper functions for direction checking ---
+
+function checkIsMovingForward(direction: string, key: string): boolean {
+  return (
+    (direction === "ltr" && key === "ArrowRight") || (direction === "rtl" && key === "ArrowLeft")
+  );
+}
+
+function checkIsMovingBackward(direction: string, key: string): boolean {
+  return (
+    (direction === "ltr" && key === "ArrowLeft") || (direction === "rtl" && key === "ArrowRight")
+  );
+}
+
+// Helper to check if the cursor can move forward from the current position
+function $canMoveForward(anchorNode: LexicalNode, selection: RangeSelection): boolean {
+  const isParaNode = $isParaNode(anchorNode);
+  const isAtNodeEnd = selection.anchor.offset === anchorNode.getTextContentSize();
+  return isParaNode || isAtNodeEnd;
+}
+
+// Helper to check if the cursor can move backward from the current position
+function $canMoveBackward(anchorNode: LexicalNode, selection: RangeSelection): boolean {
+  const isParaNode = $isParaNode(anchorNode);
+  const isAtNodeStart = selection.anchor.offset === 0;
+  return isParaNode || isAtNodeStart;
+}
+
+// Helper to handle forward arrow key navigation logic
+function $handleForwardNavigation(anchorNode: LexicalNode): boolean {
+  const nextNode = $getNextNode(anchorNode);
+  if ($isImmutableChapterNode(nextNode) || $isImmutableVerseNode(nextNode)) {
+    const nodeAfterNext = nextNode.getNextSibling();
+    // If a verse is immediately followed by a note, select the end of the note
+    if ($isNoteNode(nodeAfterNext)) nodeAfterNext.selectEnd();
+    else nextNode.selectEnd();
+    return true;
+  }
+  return false;
+}
+
+// Helper to handle backward arrow key navigation logic
+function $handleBackwardNavigation(anchorNode: LexicalNode): boolean {
+  const prevNode = $getPreviousNode(anchorNode);
+  if ($isImmutableChapterNode(prevNode) || $isImmutableVerseNode(prevNode)) {
+    prevNode.selectStart();
+    return true;
+  } else if ($isNoteNode(prevNode)) {
+    const nodeBeforePrevious = prevNode.getPreviousSibling();
+    // If a note is immediately preceded by a verse, select the start of the verse
+    if ($isImmutableVerseNode(nodeBeforePrevious)) {
+      nodeBeforePrevious.selectStart();
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/shared-react/plugins/NoteNodePlugin.test.tsx
+++ b/packages/shared-react/plugins/NoteNodePlugin.test.tsx
@@ -22,7 +22,7 @@ import {
   ImmutableVerseNode,
 } from "../nodes/scripture/usj/ImmutableVerseNode";
 import { UsjNodeOptions } from "../nodes/scripture/usj/usj-node-options.model";
-import NoteNodePlugin from "./NoteNodePlugin";
+import { NoteNodePlugin } from "./NoteNodePlugin";
 
 let firstVerseTextNode: TextNode;
 let firstNoteNode: NoteNode;


### PR DESCRIPTION
- arrow keys move over chapter and verses rather than into them
- also revert changes to `ImmutableVerseNode` from PR #295